### PR TITLE
Use documented form of plugin reference

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -62,7 +62,7 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
   }
 
   const babelEnvConfig = [
-    require('@babel/preset-env'),
+    '@babel/preset-env',
     {
       targets: {
         node: nodeVersion


### PR DESCRIPTION
Before this change, some projects using this would fail with a failure like https://github.com/electron-userland/electron-webpack/issues/125.

Additionally, this string based syntax matches the documented style from https://www.npmjs.com/package/@babel/preset-env