### PR TITLE
Reimplement exclusion of .js transforms on node versions ≥ options.nodeVersion

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -213,7 +213,7 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
     module: {
       rules: [
         {
-          loader: 'babel-loader',
+          ...babelLoaderConfig,
           test: /\.js$/,
           options: {
             presets: [ babelEnvConfig ],

--- a/test/graphql-assertions.test.js
+++ b/test/graphql-assertions.test.js
@@ -73,7 +73,7 @@ test('assertError throws if no error matches the path', async (test) => {
   test.throws(() => assertError(response, 'some.other.path', 'boom!'), `No error found with path 'some.other.path'. The paths with errors were: error`);
 });
 
-test.skip('assertError throws if the error does not match the message', async (test) => {
+test('assertError throws if the error does not match the message', async (test) => {
   const query = '{ error }';
   const response = await test.context.graphql(query);
   test.throws(() => assertError(response, 'error', 'some other message'), `'boom!' == 'some other message'`);

--- a/test/graphql-assertions.test.js
+++ b/test/graphql-assertions.test.js
@@ -73,7 +73,7 @@ test('assertError throws if no error matches the path', async (test) => {
   test.throws(() => assertError(response, 'some.other.path', 'boom!'), `No error found with path 'some.other.path'. The paths with errors were: error`);
 });
 
-test('assertError throws if the error does not match the message', async (test) => {
+test.skip('assertError throws if the error does not match the message', async (test) => {
   const query = '{ error }';
   const response = await test.context.graphql(query);
   test.throws(() => assertError(response, 'error', 'some other message'), `'boom!' == 'some other message'`);


### PR DESCRIPTION
This fixes an issue in downstream app transpiling tasks when building lambda handlers.

When node versions are not excluded, it causes havoc in the resulting lambda handler, and the execution throws an error like: `undefined is not a promise`
