### PR TITLE
ignore previously output zip file for repeatibility

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -48,9 +48,14 @@ async function zipOutputFiles (outputDir, entryNames) {
 
   for (const entryName of entryNames) {
     const dirname = path.dirname(entryName);
+    const outputZipBasename = `${entryName}.zip`;
+    const outputZipFile = path.join(outputDir, outputZipBasename);
+
     // Find all of the output files that belong to this entry
     const entriesForZipFile = (await glob(`${entryName}*`, {
-      cwd: outputDir
+      cwd: outputDir,
+      // ignore previously output zip file for repeatability
+      ignore: outputZipBasename
     })).map((file) => {
       return {
         name: (dirname === '.') ? file : file.substring(dirname.length + 1),
@@ -63,7 +68,6 @@ async function zipOutputFiles (outputDir, entryNames) {
     console.log(entriesForZipFile.map((entry) => {
       return `- ${chalk.bold(entry.name)}\n`;
     }).join(''));
-    const outputZipFile = path.join(outputDir, `${entryName}.zip`);
     await zip(outputZipFile, entriesForZipFile);
     console.log(chalk.green(`Zip file for ${chalk.bold(entryName)} written to ` +
       `${chalk.bold(makeFilePathRelativeToCwd(outputZipFile))}\n`));

--- a/test/webpack-build.test.js
+++ b/test/webpack-build.test.js
@@ -152,6 +152,29 @@ test('Lambda archives can be produced', async (test) => {
   test.truthy(zip.file('lambda_service.js'));
 });
 
+test('Lambda archives can be produced repeatably', async (test) => {
+  const source = path.join(__dirname, 'fixtures', 'lambda_service.js');
+  const bundle = path.join(test.context.buildDirectory, 'lambda_service.js.zip');
+
+  const buildConfig = {
+    entrypoint: source,
+    outputPath: test.context.buildDirectory,
+    serviceName: 'test-service',
+    zip: true
+  };
+
+  let buildResults = await build(buildConfig);
+  test.false(buildResults.hasErrors());
+  buildResults = await build(buildConfig);
+  test.false(buildResults.hasErrors());
+
+  const zip = new JSZip();
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  await zip.loadAsync(await fs.readFile(bundle));
+  test.truthy(zip.file('lambda_service.js'));
+  test.falsy(zip.file('lambda_service.js.zip'));
+});
+
 test('Multiple bundles can be produced at one time', async (test) => {
   const buildResults = await build({
     entrypoint: [


### PR DESCRIPTION
This was causing my local environment to hang indefinitely for one of our builds.