### PR TITLE
fix typo in readme - unique tables name format

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ include the following clients on the `dynamodb` attribute:
 | config           | The aws dynamodb config object, useful for passing to dynamoose or other dynamo wrappers.|
 
 If `useUniqueTables` is true, dynamically generated table names will be used, in
-the form of <tableNameProvidedInSchema>-<uuid>. The unique table name can be
+the form of `<tableNameProvidedInSchema>-<uuid>`. The unique table name can be
 fetched from the `tableNames` map. Otherwise, the table name will be the default
 provided in the schema. This allows tests to be run in parallel.
 


### PR DESCRIPTION
The markdown wasn't quite right, resulting in the following:

<kbd>
<img width="507" alt="screen shot 2018-06-26 at 10 13 12 am" src="https://user-images.githubusercontent.com/1551522/41918106-a8e2f2ae-7929-11e8-9cab-5ec72e475ac6.png">
</kbd>