### PR TITLE
Do not set attributes on native functions in patches

### DIFF
--- a/test/fixtures/runtime_dns.js
+++ b/test/fixtures/runtime_dns.js
@@ -6,7 +6,10 @@ exports.handler = (event, context, callback) => {
   const failure = new Error('simulated failure');
   failure.code = dns.NOTFOUND;
 
-  const lookup = sinon.stub(dns.lookup, '_raw')
+  // Simulate an extra pollyfill/shim
+  dns.lookup = dns.lookup.bind(dns);
+
+  const lookup = sinon.stub(dns._raw, 'lookup')
     .callsArgWith(2, failure)
     .withArgs('example.com', sinon.match.object, sinon.match.func)
     .onFirstCall().callsArgWith(2, failure)


### PR DESCRIPTION
Other shims and pollyfills may modify the native APIs after the
lambda-tools patches have been applied. This will break the
lambda-tools functionality since the expected attributes will no
longer be present.