### PR TITLE
More flexible promise support

### DIFF
--- a/src/patches/lambda.js
+++ b/src/patches/lambda.js
@@ -44,11 +44,21 @@
       done(...args);
     };
 
+    let returned = null;
+
     try {
       addAllEventHandlers(eventHandlers);
-      return handler(event, context, finish);
+      returned = handler(event, context, finish);
     } catch (error) {
       finish(error);
+      return;
+    }
+
+    if (returned && typeof returned.then === 'function') {
+      returned.then(
+        function (result) { finish(null, result); },
+        function (error) { finish(error); }
+      );
     }
   };
 

--- a/test/fixtures/runtime_promises.js
+++ b/test/fixtures/runtime_promises.js
@@ -1,0 +1,4 @@
+exports.handler = async (event, context) => {
+  await new Promise((resolve) => setImmediate(resolve));
+  return 'hello from the promised land!';
+};

--- a/test/lambda-runtime-promises.test.js
+++ b/test/lambda-runtime-promises.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs-extra');
+const path = require('path');
+const test = require('ava');
+const uuid = require('uuid/v4');
+
+const { build, useNewContainer, useLambda } = require('../src/lambda');
+
+const FIXTURES_DIRECTORY = path.join(__dirname, 'fixtures');
+const BUILD_DIRECTORY = path.join(FIXTURES_DIRECTORY, 'build', uuid());
+
+test.before(async () => {
+  const buildResults = await build({
+    entrypoint: path.join(FIXTURES_DIRECTORY, 'runtime_promises.js'),
+    outputPath: BUILD_DIRECTORY,
+    serviceName: 'runtime-promises'
+  });
+
+  if (buildResults.hasErrors()) {
+    console.error(buildResults.toJson().errors);
+    throw new Error('Lambda build failed!');
+  }
+
+  useNewContainer({
+    handler: 'runtime_promises.handler',
+    // Using Node 6.10 gives a more thorough test since this isn't normally
+    // supported.
+    image: 'lambci/lambda:nodejs6.10',
+    mountpoint: BUILD_DIRECTORY
+  });
+});
+
+useLambda(test);
+
+test.always.after((test) => fs.remove(BUILD_DIRECTORY));
+
+test.serial(`A lambda handler can return a promise`, async (test) => {
+  const result = await test.context.lambda.raw({}, {});
+  test.is(result, 'hello from the promised land!');
+});


### PR DESCRIPTION
The Lambda Node.js 8.10 runtime requires handler-returned promises
to be propper instances of the native Promise constructor. The
Node.js 6.10 runtime doesn't support handler-returned promises at
all. This change patches the runtime to use a more general
definition of a handler-returned promise that is also compatible
with the Node.js 6.10 runtime.