### PR TITLE
Detect multiple callback invocations

### DIFF
--- a/src/patches/lambda.js
+++ b/src/patches/lambda.js
@@ -39,7 +39,15 @@
       unhandledRejection: (reason, promise) => logWithContext('Unhandled rejection at:', promise, 'reason:', reason)
     };
 
+    const completions = [];
+
     const finish = (...args) => {
+      if (completions.length) {
+        logWithContext('The Lambda function called back multiple times. Note that promise resolutions are equivalent to callback invocations.');
+        logWithContext('The callback was invoked with the following sets of arguments:\n', completions);
+      }
+
+      completions.push(args);
       removeAllEventHandlers(eventHandlers);
       done(...args);
     };

--- a/test/fixtures/runtime_callbacks.js
+++ b/test/fixtures/runtime_callbacks.js
@@ -1,0 +1,5 @@
+exports.handler = async (event, context, callback) => {
+  callback(null, 'one');
+  // Returning from an async function is equivalent to invoking the callback.
+  return 'two';
+};

--- a/test/lambda-runtime-callbacks.test.js
+++ b/test/lambda-runtime-callbacks.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs-extra');
+const path = require('path');
+const test = require('ava');
+const uuid = require('uuid/v4');
+const WriteBuffer = require('../src/WriteBuffer');
+
+const { build, useNewContainer, useLambda } = require('../src/lambda');
+
+const FIXTURES_DIRECTORY = path.join(__dirname, 'fixtures');
+const BUILD_DIRECTORY = path.join(FIXTURES_DIRECTORY, 'build', uuid());
+
+test.before(async () => {
+  const buildResults = await build({
+    entrypoint: path.join(FIXTURES_DIRECTORY, 'runtime_callbacks.js'),
+    outputPath: BUILD_DIRECTORY,
+    serviceName: 'runtime-callbacks'
+  });
+
+  if (buildResults.hasErrors()) {
+    console.error(buildResults.toJson().errors);
+    throw new Error('Lambda build failed!');
+  }
+
+  useNewContainer({
+    handler: 'runtime_callbacks.handler',
+    image: 'lambci/lambda:nodejs8.10',
+    mountpoint: BUILD_DIRECTORY
+  });
+});
+
+useLambda(test);
+
+test.always.after((test) => fs.remove(BUILD_DIRECTORY));
+
+test.serial(`The lambda function logs multiple callback invocations`, async (test) => {
+  const write = process.stdout.write;
+  const buffer = new WriteBuffer();
+  process.stdout.write = buffer.write.bind(buffer);
+
+  const context = {};
+  const event = {};
+
+  try {
+    process.env.ENABLE_LAMBDA_LOGGING = true;
+    await test.context.lambda.raw(event, context);
+  } finally {
+    delete process.env.ENABLE_LAMBDA_LOGGING;
+    process.stdout.write = write;
+  }
+
+  test.regex(buffer.toString(), /called back multiple times/);
+});


### PR DESCRIPTION
The AWS runtime protects against multiple callback invocations, but
does not warn when this happens. Returning multiple responses from
a Lambda function is often a sign of a bug. Logging provides a way
to detect this.