### PR TITLE
add full error content to assertSuccess output

### DIFF
--- a/src/graphql.js
+++ b/src/graphql.js
@@ -45,7 +45,9 @@ exports.assertError = (response, path, messageTest) => {
 };
 
 exports.assertSuccess = (response) => {
-  assert(response.statusCode >= 200 && response.statusCode < 300, `Did not succeed. HTTP status code was ${response.statusCode}`);
+  assert(response.statusCode >= 200 && response.statusCode < 300,
+    `Did not succeed. HTTP status code was ${response.statusCode}` +
+    ` and error was ${JSON.stringify(response.error, null, 2)}`);
 
   const messages = map(response.body.errors, 'message').join(', ');
   assert(!response.body.errors, `Did not succeed. Errors were ${messages}`);

--- a/test/graphql-assertSuccess-httpErrors.test.js
+++ b/test/graphql-assertSuccess-httpErrors.test.js
@@ -20,5 +20,11 @@ test.before(() => {
 test('assertSuccess throws on an HTTP error', async (test) => {
   const query = '{ error }';
   const response = await test.context.graphql(query);
-  test.throws(() => assertSuccess(response), 'Did not succeed. HTTP status code was 404');
+  const expectedErrorMessage = `Did not succeed. HTTP status code was 404 and error was {
+  "status": 404,
+  "text": "Not Found",
+  "method": "POST",
+  "path": "/graphql"
+}`;
+  test.throws(() => assertSuccess(response), expectedErrorMessage);
 });


### PR DESCRIPTION
Motivation: A 500 error message appearing in the tests isn't very useful alone. The error text is much more useful in locating the root cause if nothing else is being logged.

