### PR TITLE
Remove unneded xray peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "peerDependencies": {
-    "aws-xray-sdk-core": "^2.0.0"
   }
 }


### PR DESCRIPTION
I think one more reference to X-Ray was missed in a previous X-Ray cleanup