### PR TITLE
Fix master, add support for ava 1.0 api, new way is supported in previous version…

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "glob": "^7.1.2",
     "jszip": "^3.1.5",
     "lodash": "^4.17.5",
-    "mockserver-client": "^5.3.0",
+    "mockserver-client": "5.4.1",
     "nested-error-stacks": "^2.0.0",
     "promise-retry": "^1.1.1",
     "source-map-support": "^0.5.3",

--- a/src/dynamodb.js
+++ b/src/dynamodb.js
@@ -143,10 +143,10 @@ exports.useDynamoDB = (test, useUniqueTables = false) => {
     await createTables(service, uniqueIdentifier);
   });
 
-  test.always.afterEach(async test => {
+  test.afterEach.always(async test => {
     const {dynamoClient, uniqueIdentifier} = test.context.dynamodb;
     await destroyTables(dynamoClient, uniqueIdentifier);
   });
 
-  test.always.after(test => connection.cleanup());
+  test.after.always(test => connection.cleanup());
 };

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -174,7 +174,7 @@ exports.useLambda = (test, localOptions = {}) => {
     }
   });
 
-  test.always.after(async (test) => {
+  test.after.always(async (test) => {
     await destroyLambdaExecutionEnvironment(executionEnvironment);
   });
 

--- a/test/mockServerLambda.test.js
+++ b/test/mockServerLambda.test.js
@@ -11,7 +11,7 @@ const { mockServerClient } = require('mockserver-client');
 
 const { getHostAddress, ensureImage } = require('../src/docker');
 
-const MOCKSERVER_IMAGE = 'jamesdbloom/mockserver';
+const MOCKSERVER_IMAGE = 'jamesdbloom/mockserver:mockserver-5.4.1';
 
 async function waitForMockServerToBeReady (mockServerClient) {
   await promiseRetry(async function (retry, retryNumber) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,13 +5939,13 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mockserver-client@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/mockserver-client/-/mockserver-client-5.3.0.tgz#039009892143bf2b01d3e45c3e1529c77474d4d8"
-  integrity sha512-hh3F57t/+re8OYVOQ5lrfyPXZ3B1jn8MllzXZqT1NlYGKbvjNLqfdEjx4VHb3EDE2GKAL7lrElTwyONaO9Bm2A==
+mockserver-client@5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/mockserver-client/-/mockserver-client-5.4.1.tgz#541bf60048ba2a1966df1153b6be08e41ae4628b"
+  integrity sha512-LUTYDnFYJpTu1ypAu6YwCAQGHon4tsOyRLa3SCXIpaiFPuZ+jVBT7W7GXUCJEqfbwbgQPK06ObABIr7ofKYP9w==
   dependencies:
     q "~2.0"
-    websocket "~1.0"
+    websocket "^1.0.28"
 
 module-not-found-error@^1.0.0:
   version "1.0.1"
@@ -8508,7 +8508,7 @@ webpack@^4.18.0:
     watchpack "^1.5.0"
     webpack-sources "^1.3.0"
 
-websocket@~1.0:
+websocket@^1.0.28:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.28.tgz#9e5f6fdc8a3fe01d4422647ef93abdd8d45a78d3"
   integrity sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==


### PR DESCRIPTION
…s as well

Newer versions of AVA (e.g. version 1.0.0-rc.2) will fail when `test.always.after|afterEach` is used. In older versions (e.g. 0.25.0) the order doesn't matter, either will work. So, this change won't impact older versions, but will add support for newer versions.