### PR TITLE
Allow specifying custom tsconfig file

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ You will also find the following intermediate files:
 - `./dist/lambdas/my-function.js`
 - `./dist/lambdas/my-function.js.map`
 
+**Build a TypeScript lambda function with a custom tsconfig**
+
+```bash
+ lambda-tools-build -t tsconfig-prod.json -o ./dist src/service.ts
+```
+
 **Development mode:**
 
 ```bash

--- a/bin/build.js
+++ b/bin/build.js
@@ -65,7 +65,6 @@ const buildOptions = {
 };
 
 if (argv.t) {
-  console.log('inside check');
   // assert typescript and ts-loader are installed
   ['typescript', 'ts-loader'].forEach(dependency => {
     try {

--- a/bin/build.js
+++ b/bin/build.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const path = require('path');
+const chalk = require('chalk');
 
 const { build } = require('../src/lambda');
 
@@ -44,6 +45,11 @@ const argv = require('yargs')
     describe: 'zip the JS bundle (default false)',
     type: 'boolean'
   })
+  .option('t', {
+    alias: 'tsconfig',
+    describe: 'relative path to a tsconfig.json file to compile typescript',
+    type: 'string'
+  })
   .demandCommand(1)
   .epilog(epilog)
   .argv;
@@ -54,8 +60,24 @@ const buildOptions = {
   nodeVersion: argv.n,
   outputPath: argv.o,
   serviceName: argv.s,
-  zip: argv.z
+  zip: argv.z,
+  tsconfig: argv.t
 };
+
+if (argv.t) {
+  console.log('inside check');
+  // assert typescript and ts-loader are installed
+  ['typescript', 'ts-loader'].forEach(dependency => {
+    try {
+      require.resolve(dependency);
+    } catch (_) {
+      console.error(chalk.bold.red(`It looks like you're trying to use TypeScript but do not have '${chalk.bold(
+        dependency
+      )}' installed. Please install it or remove the tsconfig flag.`));
+      process.exit(1);
+    }
+  });
+}
 
 if (argv.w) {
   // Ignore the non-literal module require because the module to load is

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
     "functions": 100,
     "branches": 100
   },
+  "optionalDependencies": {
+    "ts-loader": "*",
+    "typescript": "*"
+  },
   "devDependencies": {
     "@lifeomic/eslint-plugin-node": "^1.1.1",
     "@types/koa": "^2.0.45",
@@ -55,7 +59,9 @@
     "nyc": "^13.1.0",
     "proxyquire": "^2.0.1",
     "serverless-http": "^1.5.5",
-    "sinon": "^7.1.0"
+    "sinon": "^7.1.0",
+    "ts-loader": "^5.3.3",
+    "typescript": "^3.3.3333"
   },
   "dependencies": {
     "@babel/core": "^7.0.0",

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -204,6 +204,22 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
 
   const outputDir = path.resolve(options.outputPath || process.cwd());
 
+  const tsRule = options.tsconfig
+    ? {
+      loader: 'ts-loader',
+      options: {
+        configFile: options.tsconfig
+      }
+    } : {
+      ...babelLoaderConfig,
+      options: {
+        presets: [
+          babelEnvConfig,
+          require('@babel/preset-typescript')
+        ]
+      }
+    };
+
   const config = {
     entry,
     output: {
@@ -238,14 +254,8 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
           }
         },
         {
-          ...babelLoaderConfig,
           test: /\.ts$/,
-          options: {
-            presets: [
-              babelEnvConfig,
-              require('@babel/preset-typescript')
-            ]
-          }
+          ...tsRule
         }
       ]
     },

--- a/test/fixtures/lambda-with-tsconfig/index.ts
+++ b/test/fixtures/lambda-with-tsconfig/index.ts
@@ -1,0 +1,17 @@
+const Koa = require('koa');
+const Router = require('koa-router');
+const serverless = require('serverless-http');
+
+const app = new Koa();
+const router = new Router();
+
+router.get('/', async (context, next) => {
+  context.response.body = {
+    service: 'lambda-test',
+    parameter: process.env.TEST_PARAMETER
+  };
+  await next();
+});
+
+app.use(router.routes());
+export const handler = serverless(app);

--- a/test/fixtures/lambda-with-tsconfig/tsconfig.json
+++ b/test/fixtures/lambda-with-tsconfig/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/webpack-build.test.js
+++ b/test/webpack-build.test.js
@@ -76,6 +76,28 @@ test('The webpack configuration can be transformed', async (test) => {
   sinon.assert.calledWith(transformer, sinon.match.object);
 });
 
+test('TSConfig files are supported', async (test) => {
+  const sourceDir = path.join(__dirname, 'fixtures', 'lambda-with-tsconfig');
+  const source = path.join(sourceDir, 'index.ts');
+  const tsconfig = path.join(sourceDir, 'tsconfig.json');
+
+  const transformer = sinon.stub().returnsArg(0);
+
+  const result = await build({
+    tsconfig,
+    configTransformer: transformer,
+    entrypoint: source,
+    outputPath: test.context.buildDirectory,
+    serviceName: 'test-service'
+  });
+  test.false(result.hasErrors());
+  test.true(await fs.pathExists(path.join(test.context.buildDirectory, 'index.js')));
+  test.true(await fs.pathExists(path.join(test.context.buildDirectory, 'index.js.map')));
+
+  const config = transformer.firstCall.args[0];
+  test.truthy(config.module.rules.find(rule => rule.loader === 'ts-loader'));
+});
+
 test('Typescript bundles are supported by default', async (test) => {
   const source = path.join(__dirname, 'fixtures', 'ts_lambda_service.ts');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2693,7 +2693,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.4.2:
+chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3568,7 +3568,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.1.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
   integrity sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==
@@ -7328,7 +7328,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -8088,6 +8088,17 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+ts-loader@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.3.3.tgz#8b4af042e773132d86b3c99ef0acf3b4d325f473"
+  integrity sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^3.1.4"
+    semver "^5.0.1"
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -8141,6 +8152,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.3.3333:
+  version "3.3.3333"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
+  integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
When the `--tsconfig` argument is specified, the webpack configuration will use `ts-loader` to transpile TypeScript.