### PR TITLE
Disable namespace remapping when getting host address

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -82,7 +82,8 @@ exports.getHostAddress = async () => {
     Entrypoint: 'sh',
     HostConfig: {
       AutoRemove: true,
-      NetworkMode: 'host'
+      NetworkMode: 'host',
+      UsernsMode: 'host'
     },
     Image: DEFAULT_IMAGE,
     OpenStdin: true


### PR DESCRIPTION
User namespases are not compatible with the docker host network.
See https://docs.docker.com/engine/security/userns-remap/