### PR TITLE
Add inspect output to executeContainerCommand to be able to let clients check exit code

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -32,8 +32,8 @@ const executeContainerCommand = async ({container, command, environment}) => {
     exec.output.once('end', resolve);
     exec.output.once('error', reject);
   });
-
-  return { stderr, stdout };
+  const inspectOutput = await exec.inspect();
+  return { stderr, stdout, inspectOutput };
 };
 
 const getDefaultInterface = (routeTable) => {

--- a/test/docker-executeContainerCommand.test.js
+++ b/test/docker-executeContainerCommand.test.js
@@ -1,0 +1,13 @@
+const test = require('ava');
+const {createDefaultContainer} = require('./helpers/createDefaultContainer');
+const {executeContainerCommand} = require('../src/docker');
+
+test('response includes stdout, stderr, and inspectOutput with ExitCode 0', async (t) => {
+  const container = await createDefaultContainer();
+  await container.start();
+  const command = ['pwd'];
+  const {inspectOutput, stderr, stdout} = await executeContainerCommand({container, command});
+  t.is(stdout.toString('utf8'), '/\n');
+  t.is(stderr.toString('utf8'), '');
+  t.is(inspectOutput.ExitCode, 0);
+});

--- a/test/docker-executeContainerCommand.test.js
+++ b/test/docker-executeContainerCommand.test.js
@@ -4,10 +4,15 @@ const {executeContainerCommand} = require('../src/docker');
 
 test('response includes stdout, stderr, and inspectOutput with ExitCode 0', async (t) => {
   const container = await createDefaultContainer();
-  await container.start();
-  const command = ['pwd'];
-  const {inspectOutput, stderr, stdout} = await executeContainerCommand({container, command});
-  t.is(stdout.toString('utf8'), '/\n');
-  t.is(stderr.toString('utf8'), '');
-  t.is(inspectOutput.ExitCode, 0);
+  try {
+    await container.start();
+    const command = ['pwd'];
+    const {inspectOutput, stderr, stdout} = await executeContainerCommand({container, command});
+    t.is(stdout.toString('utf8'), '/\n');
+    t.is(stderr.toString('utf8'), '');
+    t.is(inspectOutput.ExitCode, 0);
+  } finally {
+    // don't wait for container to stop since it could take a while
+    container.stop();
+  }
 });

--- a/test/helpers/createDefaultContainer.js
+++ b/test/helpers/createDefaultContainer.js
@@ -1,0 +1,23 @@
+const Docker = require('dockerode');
+const {ensureImage} = require('../../src/docker');
+const DEFAULT_IMAGE = 'alpine:3.6';
+
+async function createDefaultContainer () {
+  const docker = new Docker();
+  await ensureImage(docker, DEFAULT_IMAGE);
+
+  return docker.createContainer({
+    Entrypoint: 'sh',
+    HostConfig: {
+      AutoRemove: true,
+      NetworkMode: 'host',
+      UsernsMode: 'host'
+    },
+    Image: DEFAULT_IMAGE,
+    OpenStdin: true
+  });
+}
+
+module.exports = {
+  createDefaultContainer
+};


### PR DESCRIPTION
Here is what inspectOutput looks like: 

{"ID":"6f52a413a767a674e4f7c6c6e386db358a8f63fd53b1e8edab64cc48918d65fe","Running":false,"ExitCode":0,"ProcessConfig":{"tty":false,"entrypoint":"node","arguments":["/opt/lifeomic/deploy/bin/launchSetupDatabase.js","global-stats-handler-test-db"],"privileged":false},"OpenStdin":false,"OpenStderr":true,"OpenStdout":true,"CanRemove":false,"ContainerID":"a68caf095d2c64217ceb4de596dd407ee8a020c7c7e012038e403c3503079baf","DetachKeys":"","Pid":57462}

This will allow us to verify successful execution of setupDatabase task in life-social-queries-service by checking the ExitCode