### PR TITLE
Log when DNS lookups are retried

### DIFF
--- a/src/patches/dns.js
+++ b/src/patches/dns.js
@@ -21,7 +21,7 @@
         // Using a logger other than the console would be ideal. Since this
         // code is injected as a patch, it is hard to get access to a better
         // logger
-        console.log(`DNS lookup of ${hostname} failed and will be retried ${remaining} more times`);
+        console.error(`DNS lookup of ${hostname} failed and will be retried ${remaining} more times`);
         setTimeout(
           () => dns._raw.lookup(hostname, options, dnsLookupWrapperResponse),
           DELAY

--- a/src/patches/dns.js
+++ b/src/patches/dns.js
@@ -18,6 +18,10 @@
 
     function dnsLookupWrapperResponse (error, address, family) {
       if (error && error.code === dns.NOTFOUND && --remaining > 0) {
+        // Using a logger other than the console would be ideal. Since this
+        // code is injected as a patch, it is hard to get access to a better
+        // logger
+        console.log(`DNS lookup of ${hostname} failed and will be retried ${remaining} more times`);
         setTimeout(
           () => dns._raw.lookup(hostname, options, dnsLookupWrapperResponse),
           DELAY

--- a/test/fixtures/runtime_dns.js
+++ b/test/fixtures/runtime_dns.js
@@ -16,7 +16,7 @@ exports.handler = (event, context, callback) => {
     .onSecondCall().callsArgWith(2, failure)
     .onThirdCall().callsArgWith(2, null, '127.0.0.1', 4);
 
-  const logSpy = sinon.stub(console, 'log');
+  const consoleSpy = sinon.stub(console, 'error');
 
   dns.lookup('example.com', (error, hostname, family) => {
     try {
@@ -25,9 +25,9 @@ exports.handler = (event, context, callback) => {
       assert.equal(family, 4);
       sinon.assert.callCount(lookup, 3);
 
-      sinon.assert.callCount(logSpy, 2);
+      sinon.assert.callCount(consoleSpy, 2);
       for (const attempt of [4, 3]) {
-        sinon.assert.calledWith(logSpy, `DNS lookup of example.com failed and will be retried ${attempt} more times`);
+        sinon.assert.calledWith(consoleSpy, `DNS lookup of example.com failed and will be retried ${attempt} more times`);
       }
     } catch (error) {
       callback(error);

--- a/test/fixtures/runtime_dns.js
+++ b/test/fixtures/runtime_dns.js
@@ -16,12 +16,19 @@ exports.handler = (event, context, callback) => {
     .onSecondCall().callsArgWith(2, failure)
     .onThirdCall().callsArgWith(2, null, '127.0.0.1', 4);
 
+  const logSpy = sinon.stub(console, 'log');
+
   dns.lookup('example.com', (error, hostname, family) => {
     try {
       assert.ifError(error);
       assert.equal(hostname, '127.0.0.1');
       assert.equal(family, 4);
       sinon.assert.callCount(lookup, 3);
+
+      sinon.assert.callCount(logSpy, 2);
+      for (const attempt of [4, 3]) {
+        sinon.assert.calledWith(logSpy, `DNS lookup of example.com failed and will be retried ${attempt} more times`);
+      }
     } catch (error) {
       callback(error);
       return;


### PR DESCRIPTION
While debugging slow Lambda cold starts, it would be helpful to see if DNS lookup retries are the cause