### PR TITLE
Allow opting out of runtime source map support

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -25,6 +25,11 @@ const argv = require('yargs')
     describe: 'the version of node that the bundle should be optimized for (default 6.10)',
     type: 'string'
   })
+  .option('disable-runtime-source-maps', {
+    describe: 'disable support for runtime source maps but still generate source maps',
+    type: 'boolean',
+    default: false
+  })
   .option('o', {
     alias: 'output-directory',
     describe: 'the path where the bundle will be produced (default: cwd)',
@@ -61,7 +66,8 @@ const buildOptions = {
   outputPath: argv.o,
   serviceName: argv.s,
   zip: argv.z,
-  tsconfig: argv.t
+  tsconfig: argv.t,
+  enableRuntimeSourceMaps: !argv['disable-runtime-source-maps']
 };
 
 if (argv.t) {

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -8,6 +8,7 @@ const chalk = require('chalk');
 const { promisify } = require('util');
 const glob = promisify(require('glob'));
 const handleWebpackResult = require('./handleWebpackResult');
+const defaults = require('lodash/defaults');
 
 const { loadPatch } = require('./patches');
 
@@ -153,6 +154,8 @@ async function expandEntrypoints (entrypoints) {
 }
 
 module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }) => {
+  options = defaults(options, { enableRuntimeSourceMaps: true });
+
   // If an entrypoint is a directory then we discover all of the entrypoints
   // within that directory.
   // For example, entrypoint might be "./src/lambdas" and we might discover
@@ -166,8 +169,12 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
   const entry = entrypoints.reduce(
     (accumulator, entry) => {
       const { file, name } = entry;
+      const preloadModules = ['@babel/polyfill'];
+      if (options.enableRuntimeSourceMaps) {
+        preloadModules.push('source-map-support/register');
+      }
       // eslint-disable-next-line security/detect-object-injection
-      accumulator[name] = ['@babel/polyfill', 'source-map-support/register', file];
+      accumulator[name] = [...preloadModules, file];
       return accumulator;
     },
     {}
@@ -220,6 +227,10 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
       }
     };
 
+  const devtool = options.enableRuntimeSourceMaps
+    ? 'source-map'
+    : 'hidden-source-map';
+
   const config = {
     entry,
     output: {
@@ -228,7 +239,7 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
       // Zipped bundles use explicit output names to determine the archive name
       filename: '[name]'
     },
-    devtool: 'source-map',
+    devtool,
     plugins,
     module: {
       rules: [


### PR DESCRIPTION
This allows people to turn off runtime source map support if low latency is a goal