### PR TITLE
Remove async/await calls after TypeScript transpilation

### DIFF
--- a/test/fixtures/typescript-es2017/async_test.ts
+++ b/test/fixtures/typescript-es2017/async_test.ts
@@ -1,0 +1,7 @@
+async function test (handler) {
+  for (const entry of [1, 2]) {
+    await handler(entry);
+  }
+}
+
+export default test;

--- a/test/fixtures/typescript-es2017/tsconfig.json
+++ b/test/fixtures/typescript-es2017/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/webpack-build.test.js
+++ b/test/webpack-build.test.js
@@ -112,6 +112,23 @@ test('Typescript bundles are supported by default', async (test) => {
   test.true(await fs.pathExists(path.join(test.context.buildDirectory, 'ts_lambda_service.js.map')));
 });
 
+test('Typescript code has async/await removed for good X-Ray integration', async (test) => {
+  const sourceRoot = path.join(__dirname, 'fixtures', 'typescript-es2017');
+  const source = path.join(sourceRoot, 'async_test.ts');
+
+  const result = await build({
+    tsconfig: path.join(sourceRoot, 'tsconfig.json'),
+    entrypoint: source,
+    outputPath: test.context.buildDirectory,
+    serviceName: 'test-service'
+  });
+  test.false(result.hasErrors());
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const contents = await fs.readFile(path.join(test.context.buildDirectory, 'async_test.js'), 'utf8');
+  test.is(/await /.test(contents), false, 'await found');
+});
+
 test('Node 6 bundles are produced by default', async (test) => {
   const source = path.join(__dirname, 'fixtures', 'lambda_service.js');
 

--- a/test/webpack-build.test.js
+++ b/test/webpack-build.test.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 const test = require('ava');
 const uuid = require('uuid/v4');
 const {createLambdaExecutionEnvironment, destroyLambdaExecutionEnvironment, LambdaRunner} = require('../src/lambda');
+const find = require('lodash/find');
 
 const SUPPORTED_NODE_VERSIONS = ['6.10', '8.10'];
 
@@ -95,7 +96,7 @@ test('TSConfig files are supported', async (test) => {
   test.true(await fs.pathExists(path.join(test.context.buildDirectory, 'index.js.map')));
 
   const config = transformer.firstCall.args[0];
-  test.truthy(config.module.rules.find(rule => rule.loader === 'ts-loader'));
+  test.truthy(config.module.rules.find(rule => find(rule.use, { loader: 'ts-loader' })));
 });
 
 test('Typescript bundles are supported by default', async (test) => {


### PR DESCRIPTION
TypeScript compilation can leave async/await calls in the code and those do no get handled correctly by X-Ray. This change removes those async/await calls