### PR TITLE
Add build option to skip minification

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -35,6 +35,11 @@ const argv = require('yargs')
     describe: 'the name of the service the bundle is for',
     type: 'string'
   })
+  .option('skip-minification', {
+    describe: 'disable minification of bundled code',
+    type: 'boolean',
+    default: false
+  })
   .option('w', {
     alias: 'webpack-transform',
     describe: 'a module that exports a function to transform the webpack configuration',
@@ -59,6 +64,7 @@ const buildOptions = {
   entrypoint: argv._,
   nodeVersion: argv.n,
   outputPath: argv.o,
+  skipMinification: argv['skip-minification'],
   serviceName: argv.s,
   zip: argv.z,
   tsconfig: argv.t

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -220,6 +220,10 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
       }
     };
 
+  const optimization = options.skipMinification
+    ? { minimize: false }
+    : { minimizer: [new TerserPlugin({ sourceMap: true })] };
+
   const config = {
     entry,
     output: {
@@ -260,9 +264,7 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
       ]
     },
     mode: process.env.WEBPACK_MODE || 'production',
-    optimization: {
-      minimizer: [ new TerserPlugin({ sourceMap: true }) ]
-    },
+    optimization,
     resolve: {
       // Since build is being called by other packages dependencies may be
       // relative to the caller or us. This cause our node modules to be

--- a/test/webpack-build.test.js
+++ b/test/webpack-build.test.js
@@ -391,3 +391,28 @@ for (const nodeVersion of SUPPORTED_NODE_VERSIONS) {
     test.false(result.hasErrors());
   });
 }
+
+async function assertMinification (test, options, expectMinification) {
+  const source = path.join(__dirname, 'fixtures', 'async_test.js');
+  const bundle = path.join(test.context.buildDirectory, 'async_test.js');
+
+  const buildResults = await build({
+    entrypoint: source,
+    outputPath: test.context.buildDirectory,
+    serviceName: 'test-service',
+    ...options
+  });
+  test.false(buildResults.hasErrors());
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const contents = await fs.readFile(bundle, 'utf8');
+  test.is(/handler\(entry\)/.test(contents), !expectMinification);
+}
+
+test('Minification is enabled by default', async (test) => {
+  await assertMinification(test, { }, true);
+});
+
+test('Minification can be skipped', async (test) => {
+  await assertMinification(test, { skipMinification: true }, false);
+});


### PR DESCRIPTION
Skipping minification shave 66% off my Lambda build time and does not have a noticeable impact on cold start times.