### PR TITLE
Fix tmp-promise dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "supertest": "^4.0.1",
     "supports-color": "^6.1.0",
     "terser-webpack-plugin": "^1.1.0",
-    "tmp-promise": "^2.0.0",
+    "tmp-promise": "^1.1.0",
     "unzipper": "^0.9.11",
     "uuid": "^3.3.2",
     "webpack": "^4.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,6 +2400,11 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+bluebird@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
+  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
+
 bluebird@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
@@ -8062,11 +8067,12 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tmp-promise@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-2.0.0.tgz#8d63f4a221a641f1085ef72baede3624aaafae13"
-  integrity sha512-kChVEhT3MTvFKrFEiKZEgDpIzUDj/EAsivMW/x0dFYPtymbLU0IkJeEJLHQ5UZfxacV3fi85NBqDDI4vT0QsYA==
+tmp-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-1.1.0.tgz#bb924d239029157b9bc1d506a6aa341f8b13e64c"
+  integrity sha512-8+Ah9aB1IRXCnIOxXZ0uFozV1nMU5xiu7hhFVUSxZ3bYu+psD4TzagCzVbexUCgNNGJnsmNDQlS4nG3mTyoNkw==
   dependencies:
+    bluebird "^3.5.0"
     tmp "0.1.0"
 
 tmp@0.1.0:


### PR DESCRIPTION
In 9c38cc1fcae5e9e7b1d57f5cef425ab9d664428d, Greenkeeper bumped from 1.0.5 to
2.0.0, which is [no longer available on NPM](https://www.npmjs.com/package/tmp-promise). This keeps me from installing the latest release of this project, `7.6.6`.