### PR TITLE
The httpOptions.timeout appears to be causing timeout issues with docker tests.

### DIFF
--- a/src/utils/awsUtils.js
+++ b/src/utils/awsUtils.js
@@ -7,9 +7,6 @@ function buildConfigFromConnection (connection) {
     credentials: new AWS.Credentials(connection.accessKey, connection.secretAccessKey),
     endpoint: new AWS.Endpoint(connection.url),
     region: connection.region,
-    httpOptions: {
-      timeout: 10000
-    },
     maxRetries: 10
   });
 }


### PR DESCRIPTION
![Timeout](https://media.giphy.com/media/fxqgaEl0Ubkyg9rmUr/giphy.gif)