### PR TITLE
Fix cleanup of unique table names

### DIFF
--- a/src/dynamodb.js
+++ b/src/dynamodb.js
@@ -46,7 +46,7 @@ async function destroyTables (dynamoClient, uniqueIdentifier) {
   const schemaTableNames = tablesSchema
     .map(({ TableName }) => getTableName(TableName, uniqueIdentifier));
   const tablesToDestroy = TableNames
-    .filter(name => schemaTableNames.includes(getTableName(name, uniqueIdentifier)));
+    .filter(name => schemaTableNames.includes(name));
 
   await Promise.all(
     tablesToDestroy


### PR DESCRIPTION
Looks like this was broken in commit a9af2be24ded23caeeff2fa29f4afe2bb743dc1b back in April. I was debugging another issue and noticed lots of duplicate/ever increasing table counts.