### PR TITLE
Fix cleanup of unique stream names

### DIFF
--- a/src/kinesis.js
+++ b/src/kinesis.js
@@ -57,7 +57,7 @@ async function destroyStreams (kinesisClient, uniqueIdentifier) {
   const streamNames = kinesisStreams
     .map(({ StreamName }) => getStreamName(StreamName, uniqueIdentifier));
   const streamsToDestroy = StreamNames
-    .filter(name => streamNames.includes(getStreamName(name, uniqueIdentifier)));
+    .filter(name => streamNames.includes(name));
 
   await Promise.all(
     streamsToDestroy


### PR DESCRIPTION
Kinesis equivalent to https://github.com/lifeomic/lambda-tools/pull/133

Thanks @DavidTanner for pointing out that there was a similar issue with the stream cleanup.