### PR TITLE
Bump fs-extra/graceful-fs...

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "babel-loader": "^8.0.2",
     "chalk": "^2.4.1",
     "dockerode": "^2.5.3",
-    "fs-extra": "^8.0.0",
+    "fs-extra": "^8.1.0",
     "glob": "^7.1.2",
     "jszip": "^3.1.5",
     "lodash": "^4.17.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4709,12 +4709,12 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^8.0.0:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.0.1.tgz#90294081f978b1f182f347a440a209154344285b"
-  integrity sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   dependencies:
-    graceful-fs "^4.1.2"
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -4977,15 +4977,10 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.0.0:
+graceful-fs@^4.0.0, graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
-
-graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 graphql-extensions@0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Ref: https://github.com/jprichardson/node-fs-extra/blob/master/CHANGELOG.md#810--2019-06-28

Fixes the following error while unzipping in `buildMountpointfromZipfile` for
large zip files:

```
RangeError: Maximum call stack size exceeded
at ReadStream (/opt/work/node_modules/@lifeomic/lambda-tools/node_modules/graceful-fs/graceful-fs.js:193:23)
at ReadStream (/opt/work/node_modules/@lifeomic/lambda-tools/node_modules/graceful-fs/graceful-fs.js:195:28)
at ReadStream (/opt/work/node_modules/@lifeomic/lambda-tools/node_modules/graceful-fs/graceful-fs.js:195:28)
...
```



Similar behavior was noticed by other consumers of graceful-fs. E.g. (write equivalent): https://github.com/serverless/serverless/issues/6667. A simple version bump seems to do the trick. The _exact_ cause isn't entirely obvious to me. A thread here seems to suggest it could be due to having multiple versions (one of which is 4.2.2) - https://github.com/isaacs/node-graceful-fs/issues/174 but I thought mine was being deduplicated by yarn/comparitable ranges. At any rate, the bump makes the problem go away.