### PR TITLE
Handle timeouts in table creation and deletion gracefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 before_script: greenkeeper-lockfile-update
-script: travis_wait 30 yarn test
+script: yarn test
 after_script: greenkeeper-lockfile-upload
 after_success: yarn coverage
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 before_script: greenkeeper-lockfile-update
-script: yarn test
+script: travis_wait 30 yarn test
 after_script: greenkeeper-lockfile-upload
 after_success: yarn coverage
 notifications:

--- a/src/dynamodb.js
+++ b/src/dynamodb.js
@@ -21,8 +21,27 @@ async function createTables (dynamoClient, uniqueIdentifier) {
       newTable.TableName = TableName;
 
       try {
-        await dynamoClient.createTable(newTable).promise();
-        await dynamoClient.waitFor('tableExists', { TableName }).promise();
+        const createRequest = dynamoClient.createTable(newTable);
+        createRequest.on('retry', response => {
+          // Do not retry table creation because it leads to
+          // ResourceInUseException when trying to create the table twice
+          response.error.retryable = false;
+        });
+
+        try {
+          await createRequest.promise();
+        } catch (e) {
+          if (e.code === 'TimeoutError') {
+            // Use a custom retry instead of the AWS provided
+            // `dynamoClient.waitFor('tableExists',` because the waitFor
+            // behavior is hardcoded to delay by 20 seconds and retry 25 times
+            await waitForReady(`Created table ${TableName}`, () =>
+              dynamoClient.describeTable({ TableName }).promise()
+            );
+          } else {
+            throw e;
+          }
+        }
       } catch (err) {
         failedProvisons.push(TableName);
         console.error(`Failed to create table "${TableName}"`, err);
@@ -52,8 +71,34 @@ async function destroyTables (dynamoClient, uniqueIdentifier) {
     tablesToDestroy
       .map(async TableName => {
         try {
-          await dynamoClient.deleteTable({ TableName }).promise();
-          await dynamoClient.waitFor('tableNotExists', { TableName }).promise();
+          const deleteRequest = dynamoClient.deleteTable({ TableName });
+
+          deleteRequest.on('retry', response => {
+            // Do not retry table deletion because it leads to
+            // ResourceNotFoundException when trying to delete the table twice
+            response.error.retryable = false;
+          });
+
+          try {
+            await deleteRequest.promise();
+          } catch (e) {
+            if (e.code === 'TimeoutError') {
+              await waitForReady(`Deleted table ${TableName}`, async () => {
+                try {
+                  await dynamoClient.describeTable({ TableName }).promise();
+                  throw new Error(`Table ${TableName} still exists`);
+                } catch (e) {
+                  if (e.code !== 'ResourceNotFoundException') {
+                    throw e;
+                  }
+
+                  // This is what we've been waiting for, the table is gone
+                }
+              });
+            } else {
+              throw e;
+            }
+          }
         } catch (err) {
           failedDeletions.push(TableName);
           console.error(`Failed to destroy table "${TableName}"`, err);

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -72,7 +72,10 @@ class LambdaRunner {
     const command = await this._buildCommand();
     const container = await this._getContainer();
     const environment = this._environment;
-    const { stderr, stdout } = await executeContainerCommand({ container, command, environment, stdin: convertEvent(event) });
+
+    const { stderr, stdout } = event === undefined
+      ? { stdout: 'Skipping execution of an undefined event. In the past this would have been an Unexpected token error\n{}', stderr: '' }
+      : await executeContainerCommand({ container, command, environment, stdin: convertEvent(event) });
 
     const output = stdout.toString('utf8').trim();
     const split = output.lastIndexOf('\n');

--- a/test/lambda/runtime-events.test.js
+++ b/test/lambda/runtime-events.test.js
@@ -36,13 +36,12 @@ useLambda(test);
 
 test.after.always(async (test) => fs.remove(BUILD_DIRECTORY));
 
-test.serial(`The lambda function logs process events`, async (test) => {
+async function testEventExecution (test, event) {
   const write = process.stdout.write;
   const buffer = new WriteBuffer();
   process.stdout.write = buffer.write.bind(buffer);
 
   const context = {};
-  const event = {};
 
   try {
     process.env.ENABLE_LAMBDA_LOGGING = true;
@@ -54,6 +53,14 @@ test.serial(`The lambda function logs process events`, async (test) => {
 
   test.notRegex(buffer.toString(), /AssertionError/);
   test.regex(buffer.toString(), /'beforeExit'/);
+}
+
+test.serial(`The lambda function logs process events`, async (test) => {
+  await testEventExecution(test, {});
+});
+
+test.serial(`The lambda function logs process string events`, async (test) => {
+  await testEventExecution(test, '{}');
 });
 
 test.serial(`Returns results when event is undefined`, async (test) => {


### PR DESCRIPTION
Timeout errors during creation and deletion should not be re-attempted, rather the tables should be monitored until the desired effect has occurred