### PR TITLE
Fixes #163 - Allow caching babel-loader directory using 'cacheDirecto…

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -60,6 +60,11 @@ const argv = require('yargs')
     describe: 'relative path to a tsconfig.json file to compile typescript',
     type: 'string'
   })
+  .options('c', {
+    alias: 'enable-cache-directory',
+    describe: 'enables babel-loader cache directory',
+    type: 'boolean'
+  })
   .demandCommand(1)
   .epilog(epilog)
   .argv;
@@ -73,7 +78,8 @@ const buildOptions = {
   serviceName: argv.s,
   zip: argv.z,
   tsconfig: argv.t,
-  enableRuntimeSourceMaps: argv['enable-runtime-source-maps']
+  enableRuntimeSourceMaps: argv['enable-runtime-source-maps'],
+  cacheDirectory: argv.c
 };
 
 if (argv.t) {

--- a/bin/build.js
+++ b/bin/build.js
@@ -60,8 +60,7 @@ const argv = require('yargs')
     describe: 'relative path to a tsconfig.json file to compile typescript',
     type: 'string'
   })
-  .options('c', {
-    alias: 'enable-cache-directory',
+  .options('enable-cache-directory', {
     describe: 'enables babel-loader cache directory',
     type: 'boolean'
   })
@@ -79,7 +78,7 @@ const buildOptions = {
   zip: argv.z,
   tsconfig: argv.t,
   enableRuntimeSourceMaps: argv['enable-runtime-source-maps'],
-  cacheDirectory: argv.c
+  cacheDirectory: argv['enable-cache-directory']
 };
 
 if (argv.t) {

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -214,6 +214,7 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
   const removeAsyncAwaitLoader = {
     loader: 'babel-loader',
     options: {
+      cacheDirectory: options.cacheDirectory,
       presets: [ babelEnvConfig ],
       plugins: [
         // X-Ray tracing cannot currently track execution across
@@ -243,6 +244,7 @@ module.exports = async ({ entrypoint, serviceName = 'test-service', ...options }
     } : {
       ...babelLoaderConfig,
       options: {
+        cacheDirectory: options.cacheDirectory,
         presets: [
           babelEnvConfig,
           require('@babel/preset-typescript')


### PR DESCRIPTION
…ry' option

This decreased my Lambda build time by ~33%.

#163 