### PR TITLE
Create and destroy tables sequentially so less errors happen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
 - '8.10.0'
 - '10'
 - '12'
+env:
+  - DEBUG_LOCALSTACK=true
 before_install:
   - yarn global add greenkeeper-lockfile@1
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/dockerode": "^2.5.20",
     "@types/koa": "^2.0.45",
     "@types/koa-router": "^7.0.28",
+    "@types/promise-retry": "^1.1.3",
     "apollo-server-koa": "^2.0.0",
     "aws-sdk-mock": "^4.0.0",
     "coveralls": "^3.0.1",

--- a/src/utils/awsUtils.d.ts
+++ b/src/utils/awsUtils.d.ts
@@ -1,4 +1,5 @@
 import {Credentials, Endpoint} from "aws-sdk";
+import { OperationOptions } from "retry";
 
 export interface SimpleServiceConfigurationOptions {
   credentials: Credentials;
@@ -27,4 +28,4 @@ export interface ConnectionAndConfig {
 
 export function buildConfigFromConnection(connection: AwsUtilsConnection): SimpleServiceConfigurationOptions;
 export function buildConnectionAndConfig(options: BuildConnectionAndConfigOptions): ConnectionAndConfig;
-export function waitForReady(awsType: string, retryFunc: () => Promise<any>): Promise<void>;
+export function waitForReady(awsType: string, retryFunc: () => Promise<any>, options: OperationOptions): Promise<void>;

--- a/src/utils/awsUtils.js
+++ b/src/utils/awsUtils.js
@@ -31,7 +31,9 @@ async function waitForReady (awsType, retryFunc, options = {}) {
     try {
       await retryFunc();
     } catch (error) {
-      retry(new NestedError(`${awsType} is still not ready after ${retryNumber} connection attempts`, error));
+      const errorMessage = `${awsType} is still not ready after ${retryNumber} connection attempts`;
+      console.log(errorMessage);
+      retry(new NestedError(errorMessage, error));
     }
   }, { minTimeout: 500, retries: 20, ...options });
 }

--- a/src/utils/awsUtils.js
+++ b/src/utils/awsUtils.js
@@ -26,14 +26,14 @@ function buildConnectionAndConfig ({
   return { connection, config };
 }
 
-async function waitForReady (awsType, retryFunc) {
+async function waitForReady (awsType, retryFunc, options = {}) {
   await promiseRetry(async function (retry, retryNumber) {
     try {
       await retryFunc();
     } catch (error) {
       retry(new NestedError(`${awsType} is still not ready after ${retryNumber} connection attempts`, error));
     }
-  }, { minTimeout: 500, retries: 20 });
+  }, { minTimeout: 500, retries: 20, ...options });
 }
 
 module.exports = {

--- a/test/localstack/elasticSearch.test.js
+++ b/test/localstack/elasticSearch.test.js
@@ -1,0 +1,29 @@
+const test = require('ava');
+
+const { LOCALSTACK_SERVICES, getConnection } = require('../../src/localstack');
+
+test.before(async t => {
+  const { mappedServices, cleanup } = await getConnection({ services: ['elasticsearch'] });
+  Object.assign(t.context, { mappedServices, cleanup });
+});
+
+test.after.always(t => {
+  const { cleanup } = t.context;
+  if (cleanup) {
+    cleanup();
+  }
+});
+
+test('elasticsearch should be available', async t => {
+  const { mappedServices } = t.context;
+  const service = mappedServices.elasticsearch;
+  await t.notThrowsAsync(service.isReady(service.client));
+});
+
+// It appears this is necessary to get code coverage.
+test('elasticsearch can configure a valid client', async t => {
+  const { mappedServices } = t.context;
+  const { config, connection } = mappedServices.elasticsearch;
+  const client = LOCALSTACK_SERVICES.elasticsearch.getClient({ config, connection });
+  await t.notThrowsAsync(LOCALSTACK_SERVICES.elasticsearch.isReady(client));
+});

--- a/test/localstack/serviceStatus.test.js
+++ b/test/localstack/serviceStatus.test.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 
 const { LOCALSTACK_SERVICES, getConnection } = require('../../src/localstack');
-const services = Object.keys(LOCALSTACK_SERVICES);
+const services = Object.keys(LOCALSTACK_SERVICES).filter(service => service !== 'elasticsearch');
 
 test.before(async t => {
   const { mappedServices, cleanup } = await getConnection({ services });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,10 +1085,22 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.7.tgz#1854f0a9aa8d2cd6818d607b3d091346c6730362"
   integrity sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==
 
+"@types/promise-retry@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/promise-retry/-/promise-retry-1.1.3.tgz#baab427419da9088a1d2f21bf56249c21b3dd43c"
+  integrity sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/range-parser@*":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/retry@*":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/serve-static@*":
   version "1.13.2"


### PR DESCRIPTION
![too fast](https://media.giphy.com/media/ltBhl4BoHaMM/giphy.gif)

Running to many creates/destroys in parallel is causing issues on my local builds.  The process is fast enough that it can be done serially.