### PR TITLE
Fix tests for elasticsearch in docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "jszip": "^3.1.5",
     "lodash": "^4.17.5",
     "nested-error-stacks": "^2.0.0",
+    "p-queue": "^6.2.1",
     "promise-retry": "^1.1.1",
     "source-map-support": "^0.5.3",
     "string-replace-loader": "^2.1.1",

--- a/src/docker.d.ts
+++ b/src/docker.d.ts
@@ -20,6 +20,6 @@ export function executeContainerCommand(
 
 export function getHostAddress(): string;
 
-export function ensureImage(): Promise<void>;
+export function ensureImage(docker: Docker, image: string): Promise<void>;
 
 export function pullImage(docker: Docker, image: string): Promise<void>;

--- a/src/kinesis.js
+++ b/src/kinesis.js
@@ -8,6 +8,7 @@ const { getHostAddress, ensureImage } = require('./docker');
 const Environment = require('./Environment');
 const { buildConnectionAndConfig, waitForReady } = require('./utils/awsUtils');
 const kinesisTools = require('./utils/kinesisTools');
+const { localstackReady } = require('./localstack');
 
 const KINESIS_IMAGE = 'localstack/localstack:latest';
 
@@ -107,6 +108,7 @@ async function getConnection () {
   });
 
   await container.start();
+  const promise = localstackReady(container);
 
   const containerData = await container.inspect();
   const host = await getHostAddress();
@@ -126,6 +128,7 @@ async function getConnection () {
     url
   });
 
+  await promise;
   const kinesisClient = new AWS.Kinesis(config);
   await waitForReady('Kinesis', async () => kinesisClient.listStreams().promise());
 

--- a/src/lambda.d.ts
+++ b/src/lambda.d.ts
@@ -100,8 +100,8 @@ export class LambdaRunner {
 
 export function useLambda<T extends LambdaTestContext>(test: TestInterface<T>, options?: LocalOptions): void;
 export function useLambdaHooks(options?: UseLambdaHooksOptions): TestHooks;
-export function useNewContainer(options?: NewContainerOptions): void;
-export function useComposeContainer(options?: ComposeContainerOptions): void;
+export function useNewContainer(options: Partial<NewContainerOptions>): void;
+export function useComposeContainer(options: Partial<ComposeContainerOptions>): void;
 export function build(options?: WebpackOptions): Promise<any>;
 export function createLambdaExecutionEnvironment(options?: CreateLambdaExecutionEnvironmentOptions): Promise<LambdaExecutionEnvironment>;
 export function destroyLambdaExecutionEnvironment(options?: DestroyLambdaExecutionEnvironmentOptions): Promise<void>;

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -206,6 +206,7 @@ async function createLambdaExecutionEnvironment (options) {
 
       await executionEnvironment.container.start();
     } catch (error) {
+      console.error(JSON.stringify({ error, container: executionEnvironment.container.id }, null, 2));
       await destroyLambdaExecutionEnvironment(executionEnvironment);
       throw error;
     }
@@ -214,7 +215,10 @@ async function createLambdaExecutionEnvironment (options) {
   return executionEnvironment;
 }
 
-async function destroyLambdaExecutionEnvironment (environment = {}) {
+async function destroyLambdaExecutionEnvironment (environment) {
+  if (!environment) {
+    return;
+  }
   const { container, network, cleanupMountpoint } = environment;
 
   if (cleanupMountpoint) {
@@ -236,7 +240,7 @@ exports.destroyLambdaExecutionEnvironment = destroyLambdaExecutionEnvironment;
 function useLambdaHooks (localOptions) {
   const impliedOptions = {};
 
-  let executionEnvironment = null;
+  let executionEnvironment = {};
 
   const getOptions = () => {
     const options = Object.assign({}, globalOptions, impliedOptions, localOptions);

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -214,7 +214,7 @@ async function createLambdaExecutionEnvironment (options) {
   return executionEnvironment;
 }
 
-async function destroyLambdaExecutionEnvironment (environment) {
+async function destroyLambdaExecutionEnvironment (environment = {}) {
   const { container, network, cleanupMountpoint } = environment;
 
   if (cleanupMountpoint) {

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -13,7 +13,7 @@ const { promisify } = require('util');
 
 const LAMBDA_TOOLS_WORK_PREFIX = '.lambda-tools-work';
 
-const LAMBDA_IMAGE = 'lambci/lambda:nodejs8.10';
+const LAMBDA_IMAGE = 'lambci/lambda:nodejs12.x';
 
 // null or undefined value means 'delete this variable'. Docker deletes variables that only have the key, without '=value'
 const createEnvironmentVariables = (environment) => Object.entries(environment)
@@ -107,6 +107,8 @@ class LambdaRunner {
 }
 
 const globalOptions = {};
+
+exports.getGlobalOptions = () => Object.assign({}, globalOptions);
 
 exports.build = webpack;
 exports.LambdaRunner = LambdaRunner;

--- a/src/localstack.d.ts
+++ b/src/localstack.d.ts
@@ -2,6 +2,7 @@ import {ServiceConfigurationOptions} from "aws-sdk/lib/service";
 import * as aws from "aws-sdk";
 import {Client as ElasticSearchClient} from "@elastic/elasticsearch";
 import {TestInterface} from "ava";
+import {Container} from "dockerode";
 
 export interface LocalStackService<T> {
   config: ServiceConfigurationOptions;
@@ -56,3 +57,4 @@ export interface Config {
 
 export function localStackHooks(config: Config): Hooks;
 export function useLocalStack<T extends LocalStackTestContext>(test: TestInterface<T>, config: Config): void;
+export function localstackReady(container: Container): Promise<void>;

--- a/src/localstack.js
+++ b/src/localstack.js
@@ -221,6 +221,7 @@ async function getConnection ({ versionTag = 'latest', services } = {}) {
       PublishAllPorts: true,
       Binds: ['/var/run/docker.sock:/var/run/docker.sock']
     },
+    User: 'localstack',
     ExposedPorts: getExposedPorts(),
     Image: image,
     Env: [

--- a/src/localstack.js
+++ b/src/localstack.js
@@ -1,5 +1,3 @@
-import {waitForReady} from './utils/awsUtils';
-
 const AWS = require('aws-sdk');
 const Docker = require('dockerode');
 const { default: PQueue } = require('p-queue');
@@ -7,7 +5,7 @@ const { Client: ElasticSearchClient } = require('@elastic/elasticsearch');
 
 const Environment = require('./Environment');
 const { getHostAddress, ensureImage } = require('./docker');
-const { buildConnectionAndConfig } = require('./utils/awsUtils');
+const { buildConnectionAndConfig, waitForReady } = require('./utils/awsUtils');
 
 const { Writable } = require('stream');
 

--- a/test/lambda/core.test.js
+++ b/test/lambda/core.test.js
@@ -1,0 +1,6 @@
+const test = require('ava');
+const { destroyLambdaExecutionEnvironment } = require('../../src/lambda');
+
+test('will not crash if no execution environment is provided', async test => {
+  await test.notThrowsAsync(destroyLambdaExecutionEnvironment());
+});

--- a/test/lambda/core.test.js
+++ b/test/lambda/core.test.js
@@ -1,6 +1,20 @@
 const test = require('ava');
-const { destroyLambdaExecutionEnvironment } = require('../../src/lambda');
+const uuid = require('uuid/v4');
+const { destroyLambdaExecutionEnvironment, useNewContainer, getGlobalOptions } = require('../../src/lambda');
 
 test('will not crash if no execution environment is provided', async test => {
   await test.notThrowsAsync(destroyLambdaExecutionEnvironment());
+});
+
+test('will not create a network id when not useComposeNetwork', t => {
+  useNewContainer({ });
+  const options = getGlobalOptions();
+  t.is(options.network, undefined);
+});
+
+test('will create a network id for the compose network', t => {
+  const composeProjectName = uuid();
+  useNewContainer({ useComposeNetwork: true });
+  const options = getGlobalOptions();
+  t.is(options.network, `${composeProjectName}_default`);
 });

--- a/test/lambda/core.test.js
+++ b/test/lambda/core.test.js
@@ -7,6 +7,7 @@ test('will not crash if no execution environment is provided', async test => {
 });
 
 test('will not create a network id when not useComposeNetwork', t => {
+  process.env.COMPOSE_PROJECT_NAME = uuid();
   useNewContainer({ });
   const options = getGlobalOptions();
   t.is(options.network, undefined);
@@ -14,6 +15,7 @@ test('will not create a network id when not useComposeNetwork', t => {
 
 test('will create a network id for the compose network', t => {
   const composeProjectName = uuid();
+  process.env.COMPOSE_PROJECT_NAME = composeProjectName;
   useNewContainer({ useComposeNetwork: true });
   const options = getGlobalOptions();
   t.is(options.network, `${composeProjectName}_default`);

--- a/test/lambda/createLambdaExecutionEnvironment.test.js
+++ b/test/lambda/createLambdaExecutionEnvironment.test.js
@@ -1,0 +1,79 @@
+const test = require('ava');
+const sinon = require('sinon');
+const uuid = require('uuid/v4');
+const docker = require('dockerode');
+
+const { createLambdaExecutionEnvironment } = require('../../src/lambda');
+
+test.beforeEach(t => {
+  const errorSpy = sinon.spy(console, 'error');
+  Object.assign(t.context, { stubbedMethods: [errorSpy], errorSpy });
+});
+
+test.afterEach(t => {
+  t.context.stubbedMethods.forEach(method => method.restore());
+});
+
+test.serial('An error is thrown if both zipfile and mountpoint arguments are provided', async (test) => {
+  await test.throwsAsync(() =>
+    createLambdaExecutionEnvironment({
+      environment: { AWS_XRAY_CONTEXT_MISSING: null },
+      mountpoint: 'someMountPoint/',
+      zipfile: 'some.zip'
+    })
+  , 'Only one of mountpoint or zipfile can be provided');
+});
+
+test.serial('Will throw an error if the image can\'t be fetched', async test => {
+  const { errorSpy } = test.context;
+  const error = await test.throwsAsync(createLambdaExecutionEnvironment({
+    mountpoint: 'someMountPoint/',
+    image: `junkity-junky/junk:${uuid()}`
+  }), '(HTTP code 404) unexpected - pull access denied for junkity-junky/junk, repository does not exist or may require \'docker login\': denied: requested access to the resource is denied ');
+  sinon.assert.calledOnce(errorSpy);
+  sinon.assert.calledWithExactly(errorSpy, 'Unable to get image', JSON.stringify({ error }, null, 2));
+});
+
+test.serial('Will throw an error if the network can\'t be created', async test => {
+  const { errorSpy } = test.context;
+  const networkError = sinon.stub(docker.prototype, 'createNetwork');
+  test.context.stubbedMethods.push(networkError);
+  const errorMessage = `A new error: ${uuid()}`;
+
+  networkError.rejects(errorMessage);
+
+  const error = await test.throwsAsync(createLambdaExecutionEnvironment({
+    mountpoint: 'invalidCharacters/'
+  }));
+  sinon.assert.calledOnce(errorSpy);
+  sinon.assert.calledWithExactly(errorSpy, 'Unable to create network', JSON.stringify({ error }, null, 2));
+});
+
+test.serial('Will throw an error if the container can\'t be created', async test => {
+  const { errorSpy } = test.context;
+  const error = await test.throwsAsync(createLambdaExecutionEnvironment({
+    mountpoint: 'invalidCharacters/',
+    network: uuid()
+  }));
+  sinon.assert.calledOnce(errorSpy);
+  sinon.assert.calledWithExactly(errorSpy, 'Unable to create container', JSON.stringify({ error }, null, 2));
+});
+
+test.serial('Will throw an error if the container can\'t start', async test => {
+  const { errorSpy } = test.context;
+  const createContainerStub = sinon.stub(docker.prototype, 'createContainer');
+  test.context.stubbedMethods.push(createContainerStub);
+  const errorMessage = `A new error: ${uuid()}`;
+  createContainerStub.resolves({
+    start: () => {
+      throw new Error(errorMessage);
+    }
+  });
+
+  const error = await test.throwsAsync(createLambdaExecutionEnvironment({
+    mountpoint: 'invalidCharacters/',
+    network: uuid()
+  }));
+  sinon.assert.calledOnce(errorSpy);
+  sinon.assert.calledWithExactly(errorSpy, 'Unable to start container', JSON.stringify({ error }, null, 2));
+});

--- a/test/lambda/tools-container-compose-network.test.js
+++ b/test/lambda/tools-container-compose-network.test.js
@@ -3,50 +3,37 @@ const sinon = require('sinon');
 const test = require('ava');
 const uuid = require('uuid/v4');
 
-const { createLambdaExecutionEnvironment, AlphaClient, destroyLambdaExecutionEnvironment } = require('../../src/lambda');
+const { useNewContainer, useLambda } = require('../../src/lambda');
 const { FIXTURES_DIRECTORY } = require('../helpers/lambda');
 
 const prefix = process.env.COMPOSE_PROJECT_NAME = uuid();
 const networkName = `${prefix}_default`;
 
-let createContainer = null;
-let network = null;
+const docker = new Docker();
 
-test.before(async (test) => {
-  const docker = new Docker();
+const createContainer = sinon.spy(Docker.prototype, 'createContainer');
 
-  createContainer = sinon.spy(Docker.prototype, 'createContainer');
-
-  network = await docker.createNetwork({
-    Internal: true,
-    Name: networkName
-  });
+const networkPromise = docker.createNetwork({
+  Internal: true,
+  Name: networkName
 });
 
-test.serial.after.always(async test => {
-  if (test.context.executionEnvironment) {
-    await destroyLambdaExecutionEnvironment(test.context.executionEnvironment);
-  }
+useLambda(test);
+
+useNewContainer({
+  handler: 'bundled_service.handler',
+  mountpoint: FIXTURES_DIRECTORY,
+  useComposeNetwork: true
+});
+
+test.serial.after.always(async (test) => {
+  const network = await networkPromise;
   createContainer.restore();
-  network.remove();
+  await network.remove();
 });
 
 test('Managed containers can use a compose network', async (test) => {
-  const handler = 'bundled_service.handler';
-  const executionEnvironment = await createLambdaExecutionEnvironment({
-    handler,
-    mountpoint: FIXTURES_DIRECTORY,
-    network: networkName
-  });
-
-  test.context.executionEnvironment = executionEnvironment;
-
-  const lambda = new AlphaClient({
-    container: executionEnvironment.container,
-    handler
-  });
-
-  const response = await lambda.get('/');
+  const response = await test.context.lambda.get('/');
   test.is(response.status, 200);
   test.is(response.data.service, 'lambda-test');
 

--- a/test/lambda/tools-container-zipfile.test.js
+++ b/test/lambda/tools-container-zipfile.test.js
@@ -51,3 +51,7 @@ test('will use mountpointParent as the directory for unzipping if provided', asy
     await tempWork.cleanup();
   }
 });
+
+test('will not crash if no execution environment is provided', async test => {
+  await test.notThrowsAsync(destroyLambdaExecutionEnvironment());
+});

--- a/test/lambda/tools-container-zipfile.test.js
+++ b/test/lambda/tools-container-zipfile.test.js
@@ -20,16 +20,6 @@ test('The helper client can create a new container', async (test) => {
   test.is(response.data.service, 'lambda-test');
 });
 
-test('An error is thrown if both zipfile and mountpoint arguments are provided', async (test) => {
-  await test.throwsAsync(() =>
-    createLambdaExecutionEnvironment({
-      environment: { AWS_XRAY_CONTEXT_MISSING: null },
-      mountpoint: path.join(FIXTURES_DIRECTORY, 'build'),
-      zipfile: 'some.zip'
-    })
-  , 'Only one of mountpoint or zipfile can be provided');
-});
-
 test('will use mountpointParent as the directory for unzipping if provided', async (test) => {
   const tempWork = await tmp.dir({ dir: process.cwd(), prefix: '.mountpointParent-test-' });
   try {
@@ -50,8 +40,4 @@ test('will use mountpointParent as the directory for unzipping if provided', asy
   } finally {
     await tempWork.cleanup();
   }
-});
-
-test('will not crash if no execution environment is provided', async test => {
-  await test.notThrowsAsync(destroyLambdaExecutionEnvironment());
 });

--- a/test/localstack/serviceStatus.test.js
+++ b/test/localstack/serviceStatus.test.js
@@ -4,7 +4,7 @@ const { LOCALSTACK_SERVICES, getConnection } = require('../../src/localstack');
 const services = Object.keys(LOCALSTACK_SERVICES);
 
 test.before(async t => {
-  const { mappedServices, cleanup } = await getConnection({ services });
+  const { mappedServices, cleanup } = await getConnection({ services, versionTag: '0.10.6' });
   Object.assign(t.context, { mappedServices, cleanup });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4321,6 +4321,11 @@ eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
+eventemitter3@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
+  integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -7340,6 +7345,21 @@ p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
+p-queue@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.2.1.tgz#809a832046451b2240a0a8e48b4fa18192b22b64"
+  integrity sha512-wV8yC/rkuWpgu9LGKJIb48OynYSrE6lVl2Bx6r8WjbyVKrFAzzQ/QevAvwnDjlD+mLt8xy0LTDOU1freOvMTCg==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    p-timeout "^3.1.0"
+
+p-timeout@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
![apt-get love](https://media.giphy.com/media/NZMjJIhAXiYBW/giphy.gif)

As of right now, the latest tag for localstack doesn't launch elasticsearch.  Pinning the test to 0.10.6.