### PR TITLE
Do setup steps predicatably

### DIFF
--- a/src/dynamodb.js
+++ b/src/dynamodb.js
@@ -264,13 +264,13 @@ exports.launchDynamoContainer = launchDynamoContainer;
 exports.useDynamoDB = (test, useUniqueTables, opts) => {
   const testHooks = dynamoDBTestHooks(useUniqueTables, opts);
 
-  test.before(testHooks.beforeAll);
+  test.serial.before(testHooks.beforeAll);
 
-  test.beforeEach(async (test) => {
+  test.serial.beforeEach(async (test) => {
     test.context.dynamodb = await testHooks.beforeEach();
   });
 
-  test.afterEach.always(async test => {
+  test.serial.afterEach.always(async test => {
     await testHooks.afterEach(test.context.dynamodb);
   });
 

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -69,7 +69,7 @@ exports.useGraphQL = (test, options) => {
   };
   options = Object.assign({}, defaults, options);
 
-  test.beforeEach((test) => {
+  test.serial.beforeEach((test) => {
     const app = setupGraphQL(test);
     assert(app, 'GraphQL setup must return a Koa application');
     const request = supertest(app.callback());

--- a/src/kinesis.js
+++ b/src/kinesis.js
@@ -181,19 +181,19 @@ function kinesisTestHooks (useUniqueStreams) {
 function useKinesisDocker (test, useUniqueStreams) {
   const testHooks = kinesisTestHooks(useUniqueStreams);
 
-  test.before(testHooks.beforeAll);
+  test.serial.before(testHooks.beforeAll);
 
-  test.beforeEach(async (test) => {
+  test.serial.beforeEach(async (test) => {
     const context = await testHooks.beforeEach();
     test.context.kinesis = context;
   });
 
-  test.afterEach.always(async test => {
+  test.serial.afterEach.always(async test => {
     const context = test.context.kinesis;
     await testHooks.afterEach(context);
   });
 
-  test.after.always(testHooks.afterAll);
+  test.serial.after.always(testHooks.afterAll);
 }
 
 function useKinesis (test, streamName) {
@@ -201,18 +201,18 @@ function useKinesis (test, streamName) {
     endpoint: process.env.KINESIS_ENDPOINT
   });
 
-  test.before(async () => {
+  test.serial.before(async () => {
     await kinesis.createStream({
       ShardCount: 1,
       StreamName: streamName
     }).promise();
   });
 
-  test.beforeEach(function (test) {
+  test.serial.beforeEach(function (test) {
     test.context.kinesis = kinesis;
   });
 
-  test.after(async () => {
+  test.serial.after(async () => {
     await kinesis.deleteStream({
       StreamName: streamName
     });

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -292,15 +292,15 @@ exports.useLambdaHooks = useLambdaHooks;
 exports.useLambda = (test, localOptions = {}) => {
   const hooks = useLambdaHooks(localOptions);
 
-  test.before(async () => {
+  test.serial.before(async () => {
     await hooks.beforeAll();
   });
 
-  test.after.always(async () => {
+  test.serial.after.always(async () => {
     await hooks.afterAll();
   });
 
-  test.beforeEach(async (test) => {
+  test.serial.beforeEach(async (test) => {
     test.context.lambda = await hooks.beforeEach();
   });
 };

--- a/src/localstack.js
+++ b/src/localstack.js
@@ -293,11 +293,11 @@ function localStackHooks ({ versionTag, services } = {}) {
 function useLocalStack (test, { versionTag, services } = {}) {
   const testHooks = localStackHooks({ versionTag, services });
 
-  test.before(async t => {
+  test.serial.before(async t => {
     t.context.localStack = await testHooks.beforeAll();
   });
 
-  test.after.always(testHooks.afterAll);
+  test.serial.after.always(testHooks.afterAll);
 }
 
 module.exports = {

--- a/test/graphql-config.test.js
+++ b/test/graphql-config.test.js
@@ -13,7 +13,9 @@ test.beforeEach((test) => {
   const { useGraphQL } = require('../src/graphql');
 
   test.context.mock = {
-    beforeEach: sinon.stub()
+    serial: {
+      beforeEach: sinon.stub()
+    }
   };
 
   test.context.useGraphQL = useGraphQL;
@@ -24,9 +26,9 @@ test.afterEach.always(resetGraphqlHelper);
 test('When a test endpoint has not been configured an error is thrown', async (test) => {
   test.context.useGraphQL(test.context.mock);
 
-  sinon.assert.calledOnce(test.context.mock.beforeEach);
+  sinon.assert.calledOnce(test.context.mock.serial.beforeEach);
   test.throws(
-    test.context.mock.beforeEach.firstCall.args[0],
+    test.context.mock.serial.beforeEach.firstCall.args[0],
     'A test GraphQL endpoint has not been configured!'
   );
 });

--- a/test/lambda/tools-container-compose-network.test.js
+++ b/test/lambda/tools-container-compose-network.test.js
@@ -43,6 +43,7 @@ test.serial.after.always(async (test) => {
 });
 
 test('Managed containers can use a compose network', async (test) => {
+  const { createContainer } = test;
   const response = await test.context.lambda.get('/');
   test.is(response.status, 200);
   test.is(response.data.service, 'lambda-test');

--- a/test/lambda/tools-container-compose-network.test.js
+++ b/test/lambda/tools-container-compose-network.test.js
@@ -43,7 +43,7 @@ test.serial.after.always(async (test) => {
 });
 
 test('Managed containers can use a compose network', async (test) => {
-  const { createContainer } = test;
+  const { createContainer } = test.context;
   const response = await test.context.lambda.get('/');
   test.is(response.status, 200);
   test.is(response.data.service, 'lambda-test');

--- a/test/lambda/tools-container-compose-network.test.js
+++ b/test/lambda/tools-container-compose-network.test.js
@@ -9,13 +9,19 @@ const { FIXTURES_DIRECTORY } = require('../helpers/lambda');
 const prefix = process.env.COMPOSE_PROJECT_NAME = uuid();
 const networkName = `${prefix}_default`;
 
-const docker = new Docker();
+test.serial.before(async t => {
+  const docker = new Docker();
 
-const createContainer = sinon.spy(Docker.prototype, 'createContainer');
+  const createContainer = sinon.spy(Docker.prototype, 'createContainer');
 
-const networkPromise = docker.createNetwork({
-  Internal: true,
-  Name: networkName
+  const network = await docker.createNetwork({
+    Internal: true,
+    Name: networkName
+  });
+  Object.assign(t.context, {
+    createContainer,
+    network
+  });
 });
 
 useLambda(test);
@@ -27,9 +33,13 @@ useNewContainer({
 });
 
 test.serial.after.always(async (test) => {
-  const network = await networkPromise;
-  createContainer.restore();
-  await network.remove();
+  const { createContainer, network } = test;
+  if (createContainer) {
+    createContainer.restore();
+  }
+  if (network) {
+    await network.remove();
+  }
 });
 
 test('Managed containers can use a compose network', async (test) => {


### PR DESCRIPTION
![out of order](https://media.giphy.com/media/fyaPlEYM1gLIc/giphy.gif)

The setup steps should be done serially.  This allows downstream projects to do some configuration before kinesis/localstack/docker, and out of order issues won't happen accidentally