### PR TITLE
Logging lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 before_script: greenkeeper-lockfile-update
+env:
+  - DEBUG=lambda-tools:*
 script: yarn test
 after_script: greenkeeper-lockfile-upload
 after_success: yarn coverage

--- a/README.md
+++ b/README.md
@@ -292,23 +292,6 @@ and relevant polyfills. When building a single bundle the output may also be
 zipped so that it is ready for upload to the Lambda environment. The CLI
 documentation may be accessed using the `lambda-tool-build --help` command.
 
-[alpha]: https://bitbucket.org/lifeomic/alpha/src/master/ "alpha"
-[ava]: https://github.com/avajs/ava "Ava"
-[aws-sdk-mock]: https://github.com/dwyl/aws-sdk-mock "aws-sdk-mock"
-[docker-compose]: https://docs.docker.com/compose/ "Docker Compose"
-[dockerode]: https://github.com/apocas/dockerode "Docker + Node = Dockerode"
-[dynamodb]: https://aws.amazon.com/documentation/dynamodb/ "DynamoDB"
-[dynamodb-client]: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html "DynamoDB Client"
-[dynamodb-create-table]: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property "DynamoDB Client: Create Table"
-[dynamodb-image]: https://hub.docker.com/r/cnadiminti/dynamodb-local/ "DynamoDB Docker Image"
-[dynamodb-local]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html "DynamoDB Local"
-[koa]: http://koajs.com/ "koa"
-[supertest]: https://github.com/visionmedia/supertest "supertest"
-[kinesis]: https://aws.amazon.com/documentation/kinesis/ "Kinesis"
-[kinesis-client]: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Kinesis.html "Kinesis Client"
-[localStack]: https://github.com/localstack/localstack "LocalStack"
-[localStack-docker]: https://hub.docker.com/r/localstack/localstack/ "LocalStack Docker"
-
 **Build all lambda functions within a directory:**
 
 ```bash
@@ -361,5 +344,29 @@ You will also find the following intermediate files:
 
 ## Debugging
 
-To debug some docker logs, set `DEBUG_DOCKER=true`.
-To debug the localstack docker container startup, set `DEBUG_LOCALSTACK=true`.
+To enable debug level logging we are using the [debug][debug] library to create the log lines.  
+There is also an environment variable `ENABLE_LAMBDA_LOGGING` available to
+print the results of a lambda run, both `stdout` and `stderr`
+Available flags are 
+- `lambda-tools:lambda`
+- `lambda-tools:docker`
+
+
+
+[alpha]: https://bitbucket.org/lifeomic/alpha/src/master/ "alpha"
+[ava]: https://github.com/avajs/ava "Ava"
+[aws-sdk-mock]: https://github.com/dwyl/aws-sdk-mock "aws-sdk-mock"
+[debug]: https://github.com/visionmedia/debug "debug"
+[docker-compose]: https://docs.docker.com/compose/ "Docker Compose"
+[dockerode]: https://github.com/apocas/dockerode "Docker + Node = Dockerode"
+[dynamodb]: https://aws.amazon.com/documentation/dynamodb/ "DynamoDB"
+[dynamodb-client]: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html "DynamoDB Client"
+[dynamodb-create-table]: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property "DynamoDB Client: Create Table"
+[dynamodb-image]: https://hub.docker.com/r/cnadiminti/dynamodb-local/ "DynamoDB Docker Image"
+[dynamodb-local]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html "DynamoDB Local"
+[koa]: http://koajs.com/ "koa"
+[supertest]: https://github.com/visionmedia/supertest "supertest"
+[kinesis]: https://aws.amazon.com/documentation/kinesis/ "Kinesis"
+[kinesis-client]: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Kinesis.html "Kinesis Client"
+[localStack]: https://github.com/localstack/localstack "LocalStack"
+[localStack-docker]: https://hub.docker.com/r/localstack/localstack/ "LocalStack Docker"

--- a/README.md
+++ b/README.md
@@ -345,11 +345,12 @@ You will also find the following intermediate files:
 ## Debugging
 
 To enable debug level logging we are using the [debug][debug] library to create the log lines.  
-There is also an environment variable `ENABLE_LAMBDA_LOGGING` available to
-print the results of a lambda run, both `stdout` and `stderr`
+
 Available flags are 
 - `lambda-tools:lambda`
 - `lambda-tools:docker`
+- `lambda-tools:localstack`
+- `lambda-tools:webpack`
 
 
 

--- a/examples/compose/docker-compose.yaml
+++ b/examples/compose/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=bogus
       - COMPOSE_PROJECT_NAME
       - DYNAMODB_ENDPOINT=http://dynamodb:8000
-      - ENABLE_LAMBDA_LOGGING
+      - DEBUG=lambda-tools:*
       - MOUNTPOINT=${PWD}/build/
     image: node:8.9.4-alpine
     volumes:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "ava": {
     "failWithoutAssertions": false,
+    "timeout": "10m",
     "files": [
       "test/**/*.test.js"
     ]

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "aws-sdk": "^2.290.0",
     "babel-loader": "^8.0.2",
     "chalk": "^3.0.0",
+    "debug": "^4.1.1",
     "dockerode": "^2.5.3",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.2",

--- a/src/docker.js
+++ b/src/docker.js
@@ -9,7 +9,8 @@ const DEFAULT_IMAGE = 'alpine:3.6';
 const DEFAULT_ROUTE_PATTERN = /^default\b.*$/m;
 const INTERFACE_ADDRESS_PATTERN = /\binet addr:\d{1,3}\.\d{1,3}.\d{1,3}\.\d{1,3}\b/m;
 
-const debugDocker = process.env.DEBUG_DOCKER === 'true';
+const { getLogger } = require('./utils/logging');
+const logger = getLogger('docker');
 
 const executeContainerCommand = async ({ container, command, environment, stdin }) => {
   const options = {
@@ -65,9 +66,7 @@ const pullImage = async (docker, image) => {
   const stream = await docker.pull(image);
   await new Promise(async (resolve, reject) => {
     docker.modem.followProgress(stream, resolve, (progress) => {
-      if (debugDocker) {
-        console.log(`${image}: ${progress.status} ${progress.progress ? progress.progress : ''}`);
-      }
+      logger.debug(`${image}: ${progress.status} ${progress.progress ? progress.progress : ''}`);
     });
   });
 };

--- a/src/dynamodb.js
+++ b/src/dynamodb.js
@@ -10,6 +10,8 @@ const { buildConnectionAndConfig, waitForReady } = require('./utils/awsUtils');
 
 const DYNAMODB_IMAGE = 'cnadiminti/dynamodb-local:latest';
 
+const logger = require('./utils/logging').getLogger('dynamodb');
+
 let tablesSchema = [];
 
 function setNotRetryable (response) {
@@ -50,7 +52,7 @@ async function createTables (dynamoClient, uniqueIdentifier) {
         }
       } catch (err) {
         failedProvisons.push(TableName);
-        console.error(`Failed to create table "${TableName}"`, JSON.stringify({ err }, null, 2));
+        logger.error(`Failed to create table "${TableName}"`, JSON.stringify({ err }, null, 2));
       }
     })
   );
@@ -59,7 +61,7 @@ async function createTables (dynamoClient, uniqueIdentifier) {
     try {
       await destroyTables(dynamoClient, uniqueIdentifier);
     } catch (err) {
-      console.error(`Failed to destroy tables after error`, err);
+      logger.error(`Failed to destroy tables after error`, err);
     }
     throw new Error(`Failed to create tables: ${failedProvisons.join(', ')}`);
   }
@@ -107,7 +109,7 @@ async function destroyTables (dynamoClient, uniqueIdentifier) {
           }
         } catch (err) {
           failedDeletions.push(TableName);
-          console.error(`Failed to destroy table "${TableName}"`, JSON.stringify({ err }, null, 2));
+          logger.error(`Failed to destroy table "${TableName}"`, JSON.stringify({ err }, null, 2));
         }
       })
   );

--- a/src/handleWebpackResult.js
+++ b/src/handleWebpackResult.js
@@ -1,7 +1,9 @@
 const supportsColor = require('supports-color');
+const { getLogger } = require('./utils/logging');
+const logger = getLogger('webpack');
 
 module.exports = (webpackResult) => {
-  console.log('Webpacking compilation result:\n', webpackResult.toString({
+  logger.info('Webpacking compilation result:\n', webpackResult.toString({
     colors: !!supportsColor.stdout,
     // hide excessive chunking output
     chunks: false,

--- a/src/kinesis.js
+++ b/src/kinesis.js
@@ -9,6 +9,7 @@ const Environment = require('./Environment');
 const { buildConnectionAndConfig, waitForReady } = require('./utils/awsUtils');
 const kinesisTools = require('./utils/kinesisTools');
 const { localstackReady } = require('./localstack');
+const logger = require('./utils/logging').getLogger('kinesis');
 
 const KINESIS_IMAGE = 'localstack/localstack:latest';
 
@@ -38,7 +39,7 @@ async function createStreams (kinesisClient, uniqueIdentifier) {
         await kinesisClient.waitFor('streamExists', { StreamName }).promise();
       } catch (err) {
         failedProvisons.push(StreamName);
-        console.error(`Failed to create stream "${StreamName}"`, err);
+        logger.error(`Failed to create stream "${StreamName}"`, err);
       }
     })
   );
@@ -47,7 +48,7 @@ async function createStreams (kinesisClient, uniqueIdentifier) {
     try {
       await destroyStreams(kinesisClient, uniqueIdentifier);
     } catch (err) {
-      console.error('Failed to destroy streams after create failed', err);
+      logger.error('Failed to destroy streams after create failed', err);
     }
     throw new Error(`Failed to create streams: ${failedProvisons.join(', ')}`);
   }
@@ -69,7 +70,7 @@ async function destroyStreams (kinesisClient, uniqueIdentifier) {
           await kinesisClient.waitFor('streamNotExists', { StreamName }).promise();
         } catch (err) {
           failedDeletions.push(StreamName);
-          console.error(`Failed to destroy stream "${StreamName}"`, err);
+          logger.error(`Failed to destroy stream "${StreamName}"`, err);
         }
       })
   );

--- a/src/utils/logging.d.ts
+++ b/src/utils/logging.d.ts
@@ -1,0 +1,9 @@
+export interface Logger {
+  info(...any): void;
+  error(...any): void;
+  warn(...any): void;
+  debug(...any): void;
+  child(name: string): Logger;
+}
+
+export function getLogger(name: string): Logger;

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,0 +1,39 @@
+const createDebug = require('debug');
+
+const libName = 'lambda-tools';
+
+const loggers = {};
+const consoleLog = console.log.bind(console);
+
+function extendLogger ({ logger, name, enabled, log }) {
+  const childLogger = logger.extend(name);
+  childLogger.log = log || logger.log;
+  childLogger.enabled = enabled || logger.enabled;
+  return childLogger;
+}
+
+function createChildLogger (name, root) {
+  return {
+    info: extendLogger({ logger: root, name: 'info', log: consoleLog, enabled: true }),
+    error: extendLogger({ logger: root, name: 'error', enabled: true }),
+    warn: extendLogger({ logger: root, name: 'warn', enabled: true }),
+    debug: extendLogger({ logger: root, name: 'debug', log: consoleLog, enabled: root.enabled }),
+    child: (name) => {
+      const child = root.extend(name);
+      child.enabled = root.enabled;
+      return createChildLogger(name, child);
+    }
+  };
+}
+
+function getLogger (name) {
+  const fullName = `${libName}:${name}`;
+  if (!loggers[fullName]) {
+    loggers[fullName] = createChildLogger(fullName, createDebug(fullName));
+  }
+  return loggers[fullName];
+}
+
+module.exports = {
+  getLogger
+};

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -11,6 +11,8 @@ const handleWebpackResult = require('./handleWebpackResult');
 const defaults = require('lodash/defaults');
 
 const { loadPatch } = require('./patches');
+const { getLogger } = require('./utils/logging');
+const logger = getLogger('webpack');
 
 const WEBPACK_DEFAULTS = new webpack.WebpackOptionsDefaulter().process({});
 const run = promisify(webpack);
@@ -44,7 +46,7 @@ function makeFilePathRelativeToCwd (file) {
  * @param {String[]} entryNames the entrypoint names from which output was produced
  */
 async function zipOutputFiles (outputDir, entryNames) {
-  console.log('\nCreating zip file for each entrypoint...\n');
+  logger.info('\nCreating zip file for each entrypoint...\n');
 
   for (const entryName of entryNames) {
     const dirname = path.dirname(entryName);
@@ -64,12 +66,12 @@ async function zipOutputFiles (outputDir, entryNames) {
     });
 
     // Now, write a zip file for each entry
-    console.log(`Creating zip for entrypoint ${chalk.bold(entryName)}...`);
-    console.log(entriesForZipFile.map((entry) => {
+    logger.info(`Creating zip for entrypoint ${chalk.bold(entryName)}...`);
+    logger.info(entriesForZipFile.map((entry) => {
       return `- ${chalk.bold(entry.name)}\n`;
     }).join(''));
     await zip(outputZipFile, entriesForZipFile);
-    console.log(chalk.green(`Zip file for ${chalk.bold(entryName)} written to ` +
+    logger.info(chalk.green(`Zip file for ${chalk.bold(entryName)} written to ` +
       `${chalk.bold(makeFilePathRelativeToCwd(outputZipFile))}\n`));
   }
 }
@@ -87,14 +89,14 @@ async function findIndexFile (dir) {
       }
     } catch (err) {
       if (err.code !== 'ENOENT') {
-        console.warn(chalk.yellow(`Unable to read possible index file ` +
+        logger.warn(chalk.yellow(`Unable to read possible index file ` +
           `${chalk.bold(candidateFile)}. ` +
           `Skipping! ${chalk.red(err.toString())}`));
       }
     }
   }
 
-  console.warn(chalk.yellow(`No index file for entrypoint in ` +
+  logger.warn(chalk.yellow(`No index file for entrypoint in ` +
     `${chalk.bold(makeFilePathRelativeToCwd(dir))} directory. ` +
     `Searched for: ${INDEX_FILES.join(', ')}`));
 

--- a/test/lambda/compose-container.test.js
+++ b/test/lambda/compose-container.test.js
@@ -1,4 +1,5 @@
 const test = require('ava');
+const debug = require('debug');
 const WriteBuffer = require('../../src/WriteBuffer');
 
 const { useLambdaContainer } = require('../helpers/lambda');
@@ -22,9 +23,9 @@ test.serial('The helper can log Lambda execution output', async (test) => {
   const write = process.stdout.write;
   const buffer = new WriteBuffer();
   process.stdout.write = buffer.write.bind(buffer);
+  debug.enable('lambda-tools:*');
 
   try {
-    process.env.ENABLE_LAMBDA_LOGGING = true;
     await test.context.lambda.get('/');
   } finally {
     delete process.env.ENABLE_LAMBDA_LOGGING;

--- a/test/lambda/compose-container.test.js
+++ b/test/lambda/compose-container.test.js
@@ -28,7 +28,6 @@ test.serial('The helper can log Lambda execution output', async (test) => {
   try {
     await test.context.lambda.get('/');
   } finally {
-    delete process.env.ENABLE_LAMBDA_LOGGING;
     process.stdout.write = write;
   }
 

--- a/test/lambda/createLambdaExecutionEnvironment.test.js
+++ b/test/lambda/createLambdaExecutionEnvironment.test.js
@@ -4,13 +4,16 @@ const uuid = require('uuid/v4');
 const docker = require('dockerode');
 
 const { createLambdaExecutionEnvironment } = require('../../src/lambda');
+const { getLogger } = require('../../src/utils/logging');
 
 test.beforeEach(t => {
-  const errorSpy = sinon.spy(console, 'error');
-  Object.assign(t.context, { stubbedMethods: [errorSpy], errorSpy });
+  const logger = getLogger('lambda');
+  const errorSpy = sinon.spy(logger, 'error');
+
+  Object.assign(t.context, { logger, stubbedMethods: [errorSpy], errorSpy });
 });
 
-test.afterEach(t => {
+test.afterEach.always(t => {
   t.context.stubbedMethods.forEach(method => method.restore());
 });
 

--- a/test/lambda/runtime-callbacks.test.js
+++ b/test/lambda/runtime-callbacks.test.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const test = require('ava');
 const uuid = require('uuid/v4');
+const debug = require('debug');
 const WriteBuffer = require('../../src/WriteBuffer');
 
 const { build, useNewContainer, useLambda } = require('../../src/lambda');
@@ -41,9 +42,9 @@ test.serial(`The lambda function logs multiple callback invocations`, async (tes
 
   const context = {};
   const event = {};
+  debug.enable('lambda-tools:*');
 
   try {
-    process.env.ENABLE_LAMBDA_LOGGING = true;
     await test.context.lambda.raw(event, context);
   } finally {
     delete process.env.ENABLE_LAMBDA_LOGGING;

--- a/test/lambda/runtime-callbacks.test.js
+++ b/test/lambda/runtime-callbacks.test.js
@@ -47,7 +47,6 @@ test.serial(`The lambda function logs multiple callback invocations`, async (tes
   try {
     await test.context.lambda.raw(event, context);
   } finally {
-    delete process.env.ENABLE_LAMBDA_LOGGING;
     process.stdout.write = write;
   }
 

--- a/test/lambda/runtime-events.test.js
+++ b/test/lambda/runtime-events.test.js
@@ -3,6 +3,7 @@ const path = require('path');
 const test = require('ava');
 const uuid = require('uuid/v4');
 const crypto = require('crypto');
+const debug = require('debug');
 
 const WriteBuffer = require('../../src/WriteBuffer');
 
@@ -40,11 +41,11 @@ async function testEventExecution (test, event) {
   const write = process.stdout.write;
   const buffer = new WriteBuffer();
   process.stdout.write = buffer.write.bind(buffer);
+  debug.enable('lambda-tools:*');
 
   const context = {};
 
   try {
-    process.env.ENABLE_LAMBDA_LOGGING = true;
     await test.context.lambda.raw(event, context);
   } finally {
     delete process.env.ENABLE_LAMBDA_LOGGING;
@@ -69,9 +70,9 @@ test.serial(`Returns results when event is undefined`, async (test) => {
   process.stdout.write = buffer.write.bind(buffer);
 
   const context = {};
+  debug.enable('lambda-tools:*');
 
   try {
-    process.env.ENABLE_LAMBDA_LOGGING = true;
     await test.context.lambda.raw(undefined, context);
   } finally {
     delete process.env.ENABLE_LAMBDA_LOGGING;
@@ -91,9 +92,9 @@ test.serial(`The lambda function can be invoked with a large event`, async test 
   const event = {
     someLargeValue: crypto.randomBytes(12584038).toString('base64') // 12584038 * 1.333 = 16777216 which is the max size. trying to send message larger than max (16780812 vs. 16777216)
   };
+  debug.enable('lambda-tools:*');
 
   try {
-    process.env.ENABLE_LAMBDA_LOGGING = true;
     await test.context.lambda.raw(event, context);
   } finally {
     delete process.env.ENABLE_LAMBDA_LOGGING;

--- a/test/lambda/runtime-events.test.js
+++ b/test/lambda/runtime-events.test.js
@@ -48,7 +48,6 @@ async function testEventExecution (test, event) {
   try {
     await test.context.lambda.raw(event, context);
   } finally {
-    delete process.env.ENABLE_LAMBDA_LOGGING;
     process.stdout.write = write;
   }
 
@@ -75,7 +74,6 @@ test.serial(`Returns results when event is undefined`, async (test) => {
   try {
     await test.context.lambda.raw(undefined, context);
   } finally {
-    delete process.env.ENABLE_LAMBDA_LOGGING;
     process.stdout.write = write;
   }
 
@@ -97,7 +95,6 @@ test.serial(`The lambda function can be invoked with a large event`, async test 
   try {
     await test.context.lambda.raw(event, context);
   } finally {
-    delete process.env.ENABLE_LAMBDA_LOGGING;
     process.stdout.write = write;
   }
 

--- a/test/localstack/getConnection.test.js
+++ b/test/localstack/getConnection.test.js
@@ -86,5 +86,5 @@ test.serial('will create a child log and debug the localstack setup', async t =>
   await cleanup();
   sinon.assert.called(logSpy);
   sinon.assert.called(debugSpy);
-  sinon.assert.calledWith(debugSpy, sinon.match(/Ready\.\n/));
+  sinon.assert.calledWith(debugSpy, sinon.match(/Ready\./));
 });

--- a/test/localstack/getConnection.test.js
+++ b/test/localstack/getConnection.test.js
@@ -4,9 +4,19 @@ const uuid = require('uuid/v4');
 const random = require('lodash/random');
 const proxyquire = require('proxyquire');
 
+const { getLogger } = require('../../src/utils/logging');
+const { getConnection } = require('../../src/localstack');
+
+test.beforeEach(t => {
+  const logger = getLogger('localstack');
+
+  Object.assign(t.context, { logger });
+});
+
 test.afterEach(t => {
-  if (console.log.restore) {
-    console.log.restore();
+  const { logger } = t.context;
+  if (logger.debug.restore) {
+    logger.debug.restore();
   }
 });
 
@@ -62,12 +72,19 @@ test('getConnection throws when invalid services are requested', async t => {
   await t.throwsAsync(getConnection({ services: [serviceName] }), `The following services are provided, (${serviceName}`);
 });
 
-test.serial('can log localstack startup logs', async t => {
-  const logSpy = sinon.spy(console, 'log');
-  process.env.DEBUG_LOCALSTACK = 'true';
-  const { getConnection } = proxyquire.noPreserveCache()('../../src/localstack', {});
+test.serial('will create a child log and debug the localstack setup', async t => {
+  const { logger } = t.context;
+  const logSpy = sinon.stub(logger, 'child');
+  let debugSpy;
+  logSpy.callsFake(function ({ container } = {}) {
+    t.not(container, null);
+    const child = logSpy.wrappedMethod.apply(this, arguments);
+    debugSpy = sinon.spy(child, 'debug');
+    return child;
+  });
   const { cleanup } = await getConnection({ services: [ 'lambda' ], versionTag: '0.10.6' });
   await cleanup();
   sinon.assert.called(logSpy);
-  sinon.assert.calledWith(logSpy, sinon.match(new RegExp('[0-9a-f]+: Ready.')));
+  sinon.assert.called(debugSpy);
+  sinon.assert.calledWith(debugSpy, sinon.match(/Ready\.\n/));
 });

--- a/test/localstack/lambdaSetup.test.js
+++ b/test/localstack/lambdaSetup.test.js
@@ -12,7 +12,7 @@ const { FIXTURES_DIRECTORY, buildLambda } = require('../helpers/lambda');
 const streamNames = ['first-stream', 'second-stream'];
 streams(streamNames);
 
-useLocalStack(test, { services: ['lambda', 'kinesis'], versionNumberTag: '0.10.3' });
+useLocalStack(test, { services: ['lambda', 'kinesis'], versionNumberTag: '0.10.6' });
 const handlerName = 'ts_lambda_kinesisHandler';
 
 const BUILD_DIRECTORY = path.join(FIXTURES_DIRECTORY, 'build', uuid());

--- a/test/localstack/useLocalStack.test.js
+++ b/test/localstack/useLocalStack.test.js
@@ -1,11 +1,9 @@
 const test = require('ava');
-const random = require('lodash/random');
 
 const { useLocalStack, LOCALSTACK_SERVICES } = require('../../src/localstack');
 
 const services = Object.keys(LOCALSTACK_SERVICES);
-const idx = random(0, services.length - 1);
-const serviceName = services[idx];
+const serviceName = 'lambda';
 
 useLocalStack(test, { services: [serviceName] });
 
@@ -30,4 +28,16 @@ services.forEach(nextServiceName => {
 test('will error when missing services', t => {
   t.throws(() => useLocalStack(test, {}));
   t.throws(() => useLocalStack(test));
+});
+
+test.serial('will return the output from localstack', t => {
+  const { localStack: { getOutput } } = t.context;
+  t.true(getOutput().includes('\nReady.'));
+});
+
+test.serial('can reset the logs', async t => {
+  const { localStack: { getOutput, clearOutput } } = t.context;
+  t.not(getOutput().length, 0);
+  clearOutput();
+  t.is(getOutput().length, 0);
 });

--- a/test/utils/logging.test.js
+++ b/test/utils/logging.test.js
@@ -1,0 +1,63 @@
+const test = require('ava');
+const proxyquire = require('proxyquire').noPreserveCache();
+const debug = require('debug');
+
+function validateLogLevelsEnabled (t, logger, debugEnabled = false) {
+  t.is(logger.info.enabled, true);
+  t.is(logger.error.enabled, true);
+  t.is(logger.warn.enabled, true);
+  t.is(logger.debug.enabled, debugEnabled);
+}
+
+function requireLogging (debugSetting = '') {
+  process.env.DEBUG = debugSetting;
+  debug.enable(debug.load());
+  return proxyquire('../../src/utils/logging', {});
+}
+
+test.serial('will default debug to disabled', t => {
+  const name = 'testLib';
+  const { getLogger } = requireLogging();
+  const logger = getLogger(name);
+  validateLogLevelsEnabled(t, logger);
+});
+
+test.serial('Multiple calls will return the same object', t => {
+  const name = 'testLib';
+  const { getLogger } = requireLogging();
+  const logger = getLogger(name);
+  validateLogLevelsEnabled(t, logger);
+  t.is(getLogger(name), logger);
+});
+
+test.serial('can enable debug logs', t => {
+  const name = 'testLib';
+  const { getLogger } = requireLogging(`lambda-tools:${name}`);
+  const logger = getLogger(name);
+  validateLogLevelsEnabled(t, logger, true);
+});
+
+test.serial('can get child logger', t => {
+  const name = 'testLib';
+  const { getLogger } = requireLogging(`lambda-tools:${name}`);
+  const logger = getLogger(name);
+  const aChild = logger.child('aChild');
+  validateLogLevelsEnabled(t, aChild, true);
+  t.is(aChild.info.namespace, `lambda-tools:${name}:aChild:info`);
+
+  const bChild = aChild.child('bChild');
+  validateLogLevelsEnabled(t, bChild, true);
+  t.is(bChild.info.namespace, `lambda-tools:${name}:aChild:bChild:info`);
+});
+
+[
+  'lambda-tools:*',
+  '*'
+].forEach(debugValue => {
+  test.serial(`can all log levels to debug using ${debugValue}`, t => {
+    const name = 'testLib';
+    const { getLogger } = requireLogging(debugValue);
+    const logger = getLogger(name);
+    validateLogLevelsEnabled(t, logger, true);
+  });
+});


### PR DESCRIPTION
![office](https://media.giphy.com/media/64bwPPy1zFEU8/giphy.gif)

@Druotic and I were discussing using a standardized logger, possibly using bunyan and debug, but ultimately the logs won't be going through any processors so debug looks the best.  This just replaces all of the `console` commands with debug logs.  `info`, `warn`, and `error` will always print out to the console, with `debug` relying on the `DEBUG` environment variable being set.  

I will do a major release with approval.