### PR TITLE
Fix typing of the raw call to alpha

### DIFF
--- a/src/lambda.d.ts
+++ b/src/lambda.d.ts
@@ -74,7 +74,7 @@ export interface AlphaClientConfig {
 
 export interface AlphaClient extends AxiosInstance {
   new (config: AlphaClientConfig);
-  raw<T = any>(event: any, environment: Environment, handler: string): Promise<T>;
+  raw<T = any>(event: any): Promise<T>;
   graphql<T = any>(
     path: string,
     query: any,


### PR DESCRIPTION
![typing](https://media.giphy.com/media/Oj5w7lOaR5ieNpuBhn/giphy.gif)

The raw query to AlphaClient accepts event and context, but only uses the event.