### PR TITLE
check config in beforeEach to prevent possibility of data corruption

### DIFF
--- a/src/dynamodb.js
+++ b/src/dynamodb.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const AWS = require('aws-sdk');
 const cloneDeep = require('lodash/cloneDeep');
 const fromPairs = require('lodash/fromPairs');
@@ -212,6 +213,7 @@ function dynamoDBTestHooks (useUniqueTables = false, opts) {
   }
 
   async function beforeEach () {
+    assert(config, 'Invalid DynamoDB test configuration.');
     const uniqueIdentifier = useUniqueTables ? uuid() : '';
     const service = new AWS.DynamoDB(config);
     const streamsClient = new AWS.DynamoDBStreams(config);
@@ -226,7 +228,6 @@ function dynamoDBTestHooks (useUniqueTables = false, opts) {
     };
 
     await createTables(service, uniqueIdentifier);
-
     return context;
   }
 

--- a/test/dynamodb/testHooks-error.test.js
+++ b/test/dynamodb/testHooks-error.test.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 const sinon = require('sinon');
 
-test('The afterAll hook handles errors in the beforeAll hook gracefully', async (test) => {
+test.serial('The afterAll hook handles errors in the beforeAll hook gracefully', async (test) => {
   // Stub the docker module to throw errors when fetching images.
   // This needs to happen before the dynamodb helper module is imported
   const docker = require('../../src/docker');
@@ -15,6 +15,30 @@ test('The afterAll hook handles errors in the beforeAll hook gracefully', async 
   try {
     await test.throwsAsync(beforeAll, { instanceOf: Error, message: error.message });
     await afterAll();
+  } finally {
+    ensureStub.restore();
+  }
+});
+
+// Some test runners (like Jest) continue to process hooks and tests even when
+// hooks fail. This can create invalid AWS clients in some cases. The clients
+// are sometimes instantiated with the default configuration which means that
+// DynamoDB test cases may execute against real tables and cause data corruption
+// or destruction.
+test.serial('the beforeEach hook does not create clients when beforeAll fails', async (test) => {
+  // Stub the docker module to throw errors when fetching images.
+  // This needs to happen before the dynamodb helper module is imported
+  const docker = require('../../src/docker');
+  const error = new Error('Stubbed failure');
+  const ensureStub = sinon.stub(docker, 'ensureImage')
+    .rejects(error);
+
+  const { dynamoDBTestHooks } = require('../../src/dynamodb');
+  const { beforeAll, beforeEach } = dynamoDBTestHooks(false);
+
+  try {
+    await test.throwsAsync(beforeAll, { instanceOf: Error, message: error.message });
+    await test.throwsAsync(beforeEach, 'Invalid DynamoDB test configuration.');
   } finally {
     ensureStub.restore();
   }


### PR DESCRIPTION
I noticed in [v8.2.0](https://github.com/lifeomic/lambda-tools/pull/120), we started having issues with intermittent errors related to Dynamo. Originally, I thought there was something functionally wrong introduced in that version. But the root cause in my case ended up just being more frequent timeouts in the beforeAll hook. It seems something about that change made the beforeAll hook slower.

However, because of the way the default test runner for Jest ~works~is broken, there's no guarantee on the ordering of hooks should one fail. See https://github.com/facebook/jest/issues/8484

There are also comments down below with more details, but the TLDR was it made tracking down the cause significantly more difficult and in some cases and if not careful, could have deleted/corrupted entire tables in a real environment.

Kudos to @jagoda for the improvement - this is his patch. I'm just opening the PR because he doesn't have GH access right now.