### PR TITLE
LX-3036: Updating AlphaClient interface types

### DIFF
--- a/src/lambda.d.ts
+++ b/src/lambda.d.ts
@@ -78,7 +78,7 @@ export interface AlphaClientConfig {
 }
 
 export interface AlphaClient extends AxiosInstance {
-  new (config: AlphaClientConfig);
+  new (config: AlphaClientConfig): AxiosInstance;
   raw<T = any>(event: any): Promise<T>;
   graphql<T = any>(
     path: string,


### PR DESCRIPTION
* The AlphaClient `new` constructor method did not have a return type, and was not valid TS.