### PR TITLE
fixing downstream TS errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/lambda-tools",
-  "version": "14.1.1",
+  "version": "14.1.2",
   "description": "Common utilities for Lambda testing and development",
   "main": "src/index.js",
   "types": "src/index.ts",

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -191,7 +191,7 @@ async function buildMountpointFromZipfile (zipfile: string, mountpointParent?: s
 
     await new Promise((resolve, reject) => {
       const endOnError = (error: Error) => reject(error);
-      unzipper.on('close', resolve);
+      unzipper.on('close', () => resolve(undefined));
       fsStream.on('error', endOnError);
       unzipper.on('error', endOnError);
     });

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -191,7 +191,7 @@ async function buildMountpointFromZipfile (zipfile: string, mountpointParent?: s
 
     await new Promise((resolve, reject) => {
       const endOnError = (error: Error) => reject(error);
-      unzipper.on('close', () => resolve());
+      unzipper.on('close', resolve);
       fsStream.on('error', endOnError);
       unzipper.on('error', endOnError);
     });


### PR DESCRIPTION
This anonymous function declaration was causing downstream type errors on linting in new projects generated by our yo service generator tool.