### PR TITLE
fixing more downstream typescript errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/lambda-tools",
-  "version": "14.1.2",
+  "version": "14.1.3",
   "description": "Common utilities for Lambda testing and development",
   "main": "src/index.js",
   "types": "src/index.ts",

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -117,7 +117,7 @@ export interface Entrypoint {
 }
 
 async function expandEntrypoints (entrypoints: Entrypoint[]) {
-  const finalEntrypoints = [];
+  const finalEntrypoints = [] as Entrypoint[];
 
   for (const entrypoint of entrypoints) {
     // eslint-disable-next-line security/detect-non-literal-fs-filename


### PR DESCRIPTION
Fixing some downstream TS errors resulting from conflicting version of TS treating untyped arrays as `never[]` vs `any[]`. This PR just properly types the array that was causing issues downstream.

We should also look into _only publishing_ the .js files. The .ts source files are also getting published and it seems to be causing mild problems for newer repos created with the yo generator when they attempt to run `tsc`.