### PR TITLE
Fix future typescript issue

### DIFF
--- a/src/utils/kinesisTools.ts
+++ b/src/utils/kinesisTools.ts
@@ -39,7 +39,7 @@ export class KinesisIterator {
     }: BasicKinesisConfig
   ) {
     assert.ok(kinesisClient, 'kinesisClient client needs to be provided');
-    assert.ok(kinesisClient.getRecords && kinesisClient.describeStream && kinesisClient.getShardIterator, 'kinesisClient client needs to be of type AWS.Kinesis');
+    assert.ok(!!kinesisClient.getRecords && !!kinesisClient.describeStream && !!kinesisClient.getShardIterator, 'kinesisClient client needs to be of type AWS.Kinesis');
     assert.ok(typeof streamName === 'string', 'streamName needs to be defined and a string');
 
     this._kinesis = kinesisClient;


### PR DESCRIPTION
## Motivation
In a future TS version (4.x), this line causes problems b/c the referenced values are non-nullable functions. Issues arise in consuming projects using that future TS operators.

I added these `!!` operators to satisfy the compiler without changing behavior.

More context: https://github.com/lifeomic/balance-service/pull/1#discussion_r633741487