### PR TITLE
Add a transpile-only option for use when using ts-loader (used when specifying a tsconfig)

### DIFF
--- a/bin/build.ts
+++ b/bin/build.ts
@@ -62,7 +62,7 @@ const argv = yargs
     type: 'string'
   })
   .option('transpile-only', {
-    describe: 'When using --tsconfig, disable typechecking in ts-loader',
+    describe: 'when using --tsconfig, disable typechecking in ts-loader',
     type: 'boolean'
   })
   .options('enable-cache-directory', {

--- a/bin/build.ts
+++ b/bin/build.ts
@@ -61,6 +61,10 @@ const argv = yargs
     describe: 'relative path to a tsconfig.json file to compile typescript',
     type: 'string'
   })
+  .option('transpile-only', {
+    describe: 'When using --tsconfig, disable typechecking in ts-loader',
+    type: 'boolean'
+  })
   .options('enable-cache-directory', {
     describe: 'enables babel-loader cache directory',
     type: 'boolean'
@@ -78,6 +82,7 @@ const buildOptions: Config = {
   serviceName: argv.s,
   zip: argv.z,
   tsconfig: argv.t,
+  transpileOnly: argv['transpile-only'],
   enableRuntimeSourceMaps: argv['enable-runtime-source-maps'],
   cacheDirectory: argv['enable-cache-directory']
 };

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -175,6 +175,7 @@ export interface Config {
   outputPath?: string;
   enableRuntimeSourceMaps?: boolean;
   tsconfig?: string;
+  transpileOnly?: boolean;
   minify?: boolean;
   configTransformer?: (config: webpack.Configuration) => webpack.Configuration;
   zip?: boolean;
@@ -250,7 +251,8 @@ export default async ({ entrypoint, serviceName = 'test-service', ...config }: C
         {
           loader: 'ts-loader',
           options: {
-            configFile: options.tsconfig
+            configFile: options.tsconfig,
+            transpileOnly: options.transpileOnly
           }
         }
       ]


### PR DESCRIPTION
Motivation: we found that typechecking with ts-loader doesn't work well OOTB. Connect-service has code that explicitly sets `transpile-only` using a webpack transformer. This allows you to set transpile-only on the build script itself which applies when using a tsconfig/ts-loader.