### PR TITLE
requestBody is optional

### DIFF
--- a/src/mockServerLambda.ts
+++ b/src/mockServerLambda.ts
@@ -5,7 +5,7 @@ export async function mockInvocation(
   mockServerClient: MockServerClient,
   functionName: string,
   responseBody: Record<string, any>,
-  requestBody: Record<string, any>,
+  requestBody?: Record<string, any>,
   times?: number,
 ): Promise<void> {
   const httpRequest: HttpRequest = {


### PR DESCRIPTION
See line 15 below. `requestBody` is supposed to be optional to allow ignoring.