### PR TITLE
External Docker check for localstack availability

### DIFF
--- a/bin/waitForLocalstack.ts
+++ b/bin/waitForLocalstack.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs';
+import { dockerLocalstackReady } from '../src/localstack';
+
+const { name, containerId, version } = yargs
+  .usage('$0 [<options>]')
+  .option('containerId', {
+    alias: 'c',
+    describe: 'the docker container ID to wait for',
+    type: 'string',
+  })
+  .option('name', {
+    alias: 'n',
+    describe: 'the name given to the container to wait for',
+    type: 'string'
+  })
+  .option('version', {
+    alias: 'v',
+    describe: 'the version of localstack to search active containers for',
+    type: 'string'
+  })
+  .demandCommand(1)
+  .argv;
+
+dockerLocalstackReady({}, { containerId, name, version })
+  .then(() => process.exit(0), (err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });

--- a/bin/waitForLocalstack.ts
+++ b/bin/waitForLocalstack.ts
@@ -13,17 +13,18 @@ const { name, containerId, version } = yargs
   .option('name', {
     alias: 'n',
     describe: 'the name given to the container to wait for',
-    type: 'string'
+    type: 'string',
   })
   .option('version', {
     alias: 'v',
     describe: 'the version of localstack to search active containers for',
-    type: 'string'
+    type: 'string',
   })
   .demandCommand(1)
   .argv;
 
-dockerLocalstackReady({}, { containerId, name, version })
+// @ts-expect-error this is to satisfy plain javascript, where the compiler won't complain.
+dockerLocalstackReady({ containerId, name, version }, {})
   .then(() => process.exit(0), (err) => {
     console.error(err);
     process.exitCode = 1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/lambda-tools",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "description": "Common utilities for Lambda testing and development",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/localstack.ts
+++ b/src/localstack.ts
@@ -378,7 +378,7 @@ export const dockerLocalstackReady = async (
   const containers: Container[] = [];
   if (containerId) {
     containers.push(await docker.getContainer(containerId));
-  } else if (name || version) {
+  } else {
     const containerInfos = await docker.listContainers({ filter: name ? `name=${name}` : `ancestor=${version}` });
     const matches = containerInfos.filter(({ Names, Image}) => (name && Names.includes(name)) || (version && Image.includes(version)));
     containers.push(...await Promise.all(matches.map((info) => docker.getContainer(info.Id))));

--- a/test/localstack/externalDocker.test.ts
+++ b/test/localstack/externalDocker.test.ts
@@ -1,0 +1,63 @@
+import test from 'ava';
+import Docker, { Container, ContainerInspectInfo } from 'dockerode';
+import { dockerLocalstackReady } from '../../src/localstack';
+import { ensureImage } from '../../src/docker';
+import { v4 as uuid } from 'uuid';
+
+const LOCALSTACK_IMAGE = 'localstack/localstack';
+
+[
+  '0.10.9',
+  '0.11.6',
+  '0.12.20',
+  '0.13.2'
+].forEach((versionTag) => {
+  const docker = new Docker();
+  let container: Container;
+  let info: ContainerInspectInfo;
+
+  test.before(async () => {
+    const image = `${LOCALSTACK_IMAGE}:${versionTag}`;
+
+    await ensureImage(docker, image);
+
+    container = await docker.createContainer({
+      HostConfig: {
+        AutoRemove: true,
+        PublishAllPorts: true,
+        Binds: [ '/var/run/docker.sock:/var/run/docker.sock' ]
+      },
+      Image: image,
+      Env: [
+        `SERVICES=s3`,
+      ]
+    });
+
+    await container.start();
+    info = await container.inspect();
+  });
+
+  test.after(async () => {
+    if (container) {
+      await container.stop();
+      // await container.remove();
+    }
+  });
+
+  test.serial(`dockerLocalstackReady ${versionTag} by containerId`, async (t) => {
+    await t.notThrowsAsync(dockerLocalstackReady(undefined, { containerId: container.id }));
+  });
+
+  test.serial(`dockerLocalstackReady ${versionTag} by name`, async (t) => {
+    await t.notThrowsAsync(dockerLocalstackReady(undefined, { name: info.Name }));
+  });
+
+  test.serial(`dockerLocalstackReady ${versionTag} by image`, async (t) => {
+    await t.notThrowsAsync(dockerLocalstackReady(undefined, { version: versionTag }));
+  });
+});
+
+test.serial(`dockerLocalstackReady no matching images provided`, async (t) => {
+  await t.notThrowsAsync(dockerLocalstackReady(undefined, { name: uuid() }));
+});
+

--- a/test/localstack/version10Status.test.js
+++ b/test/localstack/version10Status.test.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 
 const { LOCALSTACK_SERVICES, getConnection } = require('../../src/localstack');
-const services = Object.keys(LOCALSTACK_SERVICES);
+const services = Object.keys(LOCALSTACK_SERVICES).filter((service) => service !== 'elasticsearch');
 
 test.before(async t => {
   const { mappedServices, cleanup } = await getConnection({ services, versionTag: '0.10.9' });

--- a/test/localstack/version12Status.test.js
+++ b/test/localstack/version12Status.test.js
@@ -4,7 +4,7 @@ const { LOCALSTACK_SERVICES, getConnection, waitForServicesToBeReady } = require
 const services = Object.keys(LOCALSTACK_SERVICES);
 
 test.before(async t => {
-  const { mappedServices, cleanup } = await getConnection({ services, versionTag: '0.12.2' });
+  const { mappedServices, cleanup } = await getConnection({ services, versionTag: '0.12.20' });
   Object.assign(t.context, { mappedServices, cleanup });
 });
 

--- a/test/localstack/version13Status.test.js
+++ b/test/localstack/version13Status.test.js
@@ -1,10 +1,14 @@
 const test = require('ava');
 
-const { LOCALSTACK_SERVICES, getConnection } = require('../../src/localstack');
+const {
+  LOCALSTACK_SERVICES,
+  getConnection,
+  waitForServicesToBeReady
+} = require('../../src/localstack');
 const services = Object.keys(LOCALSTACK_SERVICES);
 
 test.before(async t => {
-  const { mappedServices, cleanup } = await getConnection({ services, versionTag: '0.10.9' });
+  const { mappedServices, cleanup } = await getConnection({ services, versionTag: '0.13.2' });
   Object.assign(t.context, { mappedServices, cleanup });
 });
 
@@ -16,9 +20,6 @@ test.after.always(async t => {
 });
 
 services.forEach(serviceName => {
-  if (serviceName === 'events') {
-    return;
-  }
   test(`${serviceName} should be available`, async t => {
     const { mappedServices } = t.context;
     const service = mappedServices[serviceName];
@@ -32,4 +33,15 @@ services.forEach(serviceName => {
     const client = LOCALSTACK_SERVICES[serviceName].getClient({ config, connection });
     await t.notThrowsAsync(LOCALSTACK_SERVICES[serviceName].isReady(client));
   });
+});
+
+test.serial('waitForServicesToBeReady', async t => {
+  const { mappedServices } = t.context;
+  const servicesConfigs = Object.keys(mappedServices).reduce((acc, serviceName) => ({
+    ...acc,
+    [serviceName]: {
+      url: mappedServices[serviceName].connection.url
+    }
+  }), {});
+  await t.notThrowsAsync(waitForServicesToBeReady(servicesConfigs));
 });


### PR DESCRIPTION
![candles](https://media.giphy.com/media/3oEdvanlXvozVLoIqQ/giphy.gif)

Export a method to check if a docker instance of localstack has finished setting up.

It is fairly common to need to wait for localstack to be running before setting up lambda, creating dynamo tables, etc.  This let us wait till the service is actually ready before making calls, instead of a long pause and checking each service, which can cause localstack to crash.