### PR TITLE
chore: remove prereleasing

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,7 +1,6 @@
 name: PR Build and Test
 
-on:
-  pull_request
+on: pull_request
 
 jobs:
   test:
@@ -30,26 +29,6 @@ jobs:
           path-to-lcov: .nyc_output/lcov.info
           flag-name: run-${{ matrix.node }}
           parallel: true
-  preRelease:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org
-      - name: Install
-        run: yarn install --frozen-lockfile
-      - name: Version
-        env:
-          PRE_ID: pr-${{ github.event.number }}-${{ github.run_id }}
-        run: npm version prepatch --git-tag-version=false --preid="${PRE_ID}-$(date '+%s')"
-      - name: PrePublish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.LIFEOMIC_NPM_TOKEN}}
-          PR_TAG: pr-${{ github.event.number }}
-        run: npm publish --tag "${PR_TAG}"
   finish:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation
In our new workflow for publishing NPM packages, pre-releasing on PRs is not supported.

We haven't yet identified a good solution -- for now, `yarn link` needs to be used.