### PR TITLE
Expand configuration, and fix localstack hang when waiting for docker

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Node.JS ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ coverage/
 src/lambda.js
 src/localstack.js
 src/dynamodb.js
+CertificateAuthorityCertificate.pem
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/lambda-tools",
-  "version": "15.1.1",
+  "version": "15.1.2",
   "description": "Common utilities for Lambda testing and development",
   "main": "src/index.js",
   "types": "src/index.d.ts",
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@lifeomic/alpha": "^1.4.1",
     "@lifeomic/eslint-plugin-node": "^2.0.1",
+    "@types/node": "^12.20.43",
     "@types/sinon": "^9.0.10",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",

--- a/test/localstack/externalDocker.test.ts
+++ b/test/localstack/externalDocker.test.ts
@@ -10,7 +10,8 @@ const versions = [
   '0.10.9',
   '0.11.6',
   '0.12.20',
-  '0.13.2'
+  '0.13.2',
+  '0.14.0'
 ] as const;
 const docker = new Docker();
 

--- a/test/localstack/localstackNameTags.test.ts
+++ b/test/localstack/localstackNameTags.test.ts
@@ -13,9 +13,10 @@ test.afterEach(async (t) => {
   'light',
   'full',
   undefined,
-].forEach((nameTag) => {
+].forEach((nameExtension) => {
+  const nameTag = nameExtension as 'full' | 'light' | undefined;
   test.serial(`will use docker tag localstack/localstack${nameTag ? `-${nameTag}` : ''}:0.14.0`, async (t) => {
-    const { mappedServices, cleanup } = await getConnection({ services: ['s3'], versionTag: '0.14.0' });
+    const { mappedServices, cleanup } = await getConnection({ services: ['s3'], versionTag: '0.14.0', nameTag });
     const { isReady, client } = mappedServices.s3;
     t.context.cleanup = cleanup;
     await t.notThrowsAsync(isReady(client));

--- a/test/localstack/localstackNameTags.test.ts
+++ b/test/localstack/localstackNameTags.test.ts
@@ -1,0 +1,24 @@
+import anyTest, { TestInterface } from 'ava';
+import { getConnection } from '../../src/localstack';
+
+const test = anyTest as TestInterface<{ cleanup?: () => Promise<void> }>;
+
+test.afterEach(async (t) => {
+  if (t.context.cleanup) {
+    await t.context.cleanup();
+  }
+});
+
+[
+  'light',
+  'full',
+  undefined,
+].forEach((nameTag) => {
+  test.serial(`will use docker tag localstack/localstack${nameTag ? `-${nameTag}` : ''}:0.14.0`, async (t) => {
+    const { mappedServices, cleanup } = await getConnection({ services: ['s3'], versionTag: '0.14.0' });
+    const { isReady, client } = mappedServices.s3;
+    t.context.cleanup = cleanup;
+    await t.notThrowsAsync(isReady(client));
+  });
+});
+

--- a/test/localstack/version14Status.test.ts
+++ b/test/localstack/version14Status.test.ts
@@ -1,0 +1,51 @@
+import anyTest, { TestInterface } from 'ava';
+
+import {
+  LOCALSTACK_SERVICES,
+  getConnection,
+  waitForServicesToBeReady,
+  LocalStackServices,
+  LocalStackService,
+} from '../../src/localstack';
+const services = Object.keys(LOCALSTACK_SERVICES) as (keyof LocalStackServices)[];
+
+const test = anyTest as TestInterface<{ cleanup?: () => Promise<void>; mappedServices: Record<keyof LocalStackServices, LocalStackService> }>
+
+test.before(async t => {
+  const { mappedServices, cleanup } = await getConnection({ services, versionTag: '0.14.0' });
+  Object.assign(t.context, { mappedServices, cleanup });
+});
+
+test.after.always(async t => {
+  const { cleanup } = t.context;
+  if (cleanup) {
+    await cleanup();
+  }
+});
+
+services.forEach((serviceName) => {
+  test(`${serviceName} should be available`, async (t) => {
+    const { mappedServices } = t.context;
+    const service = mappedServices[serviceName];
+    await t.notThrowsAsync(service.isReady(service.client));
+  });
+
+  // It appears this is necessary to get code coverage.
+  test(`${serviceName} can configure a valid client`, async (t) => {
+    const { mappedServices } = t.context;
+    const { config, connection } = mappedServices[serviceName];
+    const client = LOCALSTACK_SERVICES[serviceName].getClient({ config, connection });
+    await t.notThrowsAsync(LOCALSTACK_SERVICES[serviceName].isReady(client));
+  });
+});
+
+test.serial('waitForServicesToBeReady', async (t) => {
+  const { mappedServices } = t.context;
+  const servicesConfigs = Object.keys(mappedServices).reduce((acc, serviceName) => ({
+    ...acc,
+    [serviceName]: {
+      url: mappedServices[serviceName as keyof LocalStackServices].connection.url
+    }
+  }), {});
+  await t.notThrowsAsync(waitForServicesToBeReady(servicesConfigs));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,6 +1633,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.7.tgz#1854f0a9aa8d2cd6818d607b3d091346c6730362"
   integrity sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==
 
+"@types/node@^12.20.43":
+  version "12.20.43"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.43.tgz#6cf47894da4a4748c62fccf720ba269e1b1ff5a4"
+  integrity sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA==
+
 "@types/node@^14.6.1":
   version "14.14.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"


### PR DESCRIPTION
![life forever](https://media.giphy.com/media/ohdmJuMIE08Ld7Jj0s/giphy.gif)

The external docker function was never closing for docker compose setups.  Once we get the `Ready.` message, we don't need to listen to the container anymore.