### PR TITLE
Stop publishing source files

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -20,6 +20,8 @@ jobs:
         env:
           LAMBDA_REMOTE_DOCKER: true
         run: yarn test
+      - name: Build
+        run: yarn build
       - name: Coverage
         run: yarn coverage
       - name: Coveralls

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
         env:
           LAMBDA_REMOTE_DOCKER: true
         run: yarn test
+      - name: Build
+        run: yarn build
       - name: Coverage # Only needed if the test command doesn't already output a report, like with Jest
         run: yarn coverage # the coverage command should output results to <REPO_ROOT>/.nyc_output/lcov.info
       - name: Coverage Report

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ src/lambda.js
 src/localstack.js
 src/dynamodb.js
 CertificateAuthorityCertificate.pem
-
+dist

--- a/build-package.js
+++ b/build-package.js
@@ -1,0 +1,13 @@
+const { execSync } = require('child_process');
+
+const run = (cmd) => execSync(cmd, { stdio: 'inherit' });
+
+run('rm -rf dist/');
+
+run('yarn tsc');
+
+for (const file of ['package.json', 'LICENSE', 'CHANGELOG.md', 'README.md']) {
+  run(`cp ${file} dist/`);
+}
+
+console.log('✔️ Successfully built library to dist folder');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lambda-tools-wait-for-localstack": "./bin/wait-for-localstack.js"
   },
   "scripts": {
-    "prepublishOnly": "yarn tsc",
+    "build": "node build-package.js",
     "coverage": "nyc report --reporter=text-lcov > ./.nyc_output/lcov.info",
     "lint": "eslint . --ext .js,.ts -f codeframe",
     "pretest": "yarn lint && tsc --noEmit",

--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,7 @@ module.exports = {
   branches: ['master'],
   plugins: [
     ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
-    ['@semantic-release/npm'],
+    ['@semantic-release/npm', { pkgRoot: 'dist/' }],
     [
       '@semantic-release/github',
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,13 +18,9 @@
     "resolveJsonModule": true,
     "rootDir": ".",
     "skipLibCheck": true,
-    "declaration": true
+    "declaration": true,
+    "outDir": "./dist"
   },
-  "include": [
-    "src/**/*",
-    "bin/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*", "bin/*"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
**NOTE**: this PR depends on #303.

## Motivation
This library has incorrectly published its `.ts` files for a _long_ time. This often unnecessarily causes compilation errors in downstream projects, especially when building. We should stop.