### PR TITLE
fix: add allowJs to re-include pure js files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "rootDir": ".",
     "skipLibCheck": true,
     "declaration": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "allowJs": true
   },
   "include": ["src/**/*", "bin/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Motivation
Some pure JS files were removed from the `dist`, breaking the library.