### PR TITLE
fix: skip compilation of patch files because they cause issues when bundling

### DIFF
--- a/build-package.js
+++ b/build-package.js
@@ -10,4 +10,8 @@ for (const file of ['package.json', 'LICENSE', 'CHANGELOG.md', 'README.md']) {
   run(`cp ${file} dist/`);
 }
 
+// Explicitly copy 'js' patch files because they are not
+// compiled + moved by typescript
+run('cp src/patches/*.js dist/src/patches');
+
 console.log('✔️ Successfully built library to dist folder');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "allowJs": true
   },
   "include": ["src/**/*", "bin/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/patches/*.js"]
 }


### PR DESCRIPTION
With some of the recent changes the `patch` files end up having inlined source maps that don't get handled well when pasting those files in with the `WrapperPlugin`.  This fixes it by not explicitly compiling those but copying them over (this seems to match the previous behavior from looking at other outputs)