### PR TITLE
fix: don't use test-service as a service name default

### DIFF
--- a/bin/build.ts
+++ b/bin/build.ts
@@ -70,6 +70,7 @@ const argv = yargs
     type: 'boolean'
   })
   .demandCommand(1)
+  .demandOption(['s'])
   .epilog(epilogue)
   .argv;
 

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -181,7 +181,7 @@ export interface Config {
   zip?: boolean;
 }
 
-export default async ({ entrypoint, serviceName = 'test-service', ...config }: Config) => {
+export default async ({ entrypoint, serviceName, ...config }: Config) => {
   const options = defaults(config, { enableRuntimeSourceMaps: false });
 
   // If an entrypoint is a directory then we discover all of the entrypoints


### PR DESCRIPTION
I know this is _technically_ a br3aking change, but I consider it more of a critical bug fix. I'd like to force adopters to do this if upgrading at all, and not just if they do a major version bump.