### PR TITLE
No task/handle config entrypoint

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -74,7 +74,7 @@ export async function destroyLambdaExecutionEnvironment (environment: ExecutionE
 }
 
 export async function getEntrypoint (docker: Docker, imageName: string): Promise<string[]> {
-  const image = await (docker.getImage(imageName)).inspect();
+  const image = await docker.getImage(imageName).inspect();
   const entryPoint = image.ContainerConfig.Entrypoint ?? image.Config.Entrypoint;
 
   if (entryPoint) {

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -73,7 +73,7 @@ export async function destroyLambdaExecutionEnvironment (environment: ExecutionE
   }
 }
 
-async function getEntrypoint (docker: Docker, imageName: string): Promise<string[]> {
+export async function getEntrypoint (docker: Docker, imageName: string): Promise<string[]> {
   const image = await (docker.getImage(imageName)).inspect();
   const entryPoint = image.ContainerConfig.Entrypoint ?? image.Config.Entrypoint;
 

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -74,10 +74,11 @@ export async function destroyLambdaExecutionEnvironment (environment: ExecutionE
 }
 
 async function getEntrypoint (docker: Docker, imageName: string): Promise<string[]> {
-  const image = await (await docker.getImage(imageName)).inspect();
+  const image = await (docker.getImage(imageName)).inspect();
+  const entryPoint = image.ContainerConfig.Entrypoint ?? image.Config.Entrypoint;
 
-  if (image.ContainerConfig.Entrypoint) {
-    return flatten([image.ContainerConfig.Entrypoint]);
+  if (entryPoint) {
+    return flatten([entryPoint]);
   } else {
     const parentImageName = image.Parent;
     assert(parentImageName, `The image ${imageName} has no entrypoint and no parent image`);

--- a/test/lambda/entrypoint.test.js
+++ b/test/lambda/entrypoint.test.js
@@ -1,0 +1,27 @@
+const test = require('ava');
+const sinon = require('sinon');
+const Dockerode = require('dockerode');
+const { useLambdaHooks } = require('../../src/lambda');
+
+test.afterEach(() => {
+  sinon.restore();
+});
+
+test.serial('should fail to get entrypoint', async (test) => {
+  const imageName = 'random';
+  const errorMessage = `The image ${imageName} has no entrypoint and no parent image`;
+  const containerInspectStub = sinon.stub(Dockerode.Container.prototype, 'inspect').resolves({ Image: imageName });
+  const imageInspectStub = sinon.stub(Dockerode.Image.prototype, 'inspect').resolves({
+    Config: {},
+    ContainerConfig: {}
+  });
+  sinon.stub(Dockerode.prototype, 'getContainer').resolves({ inspect: containerInspectStub });
+  sinon.stub(Dockerode.prototype, 'getImage').returns({ inspect: imageInspectStub });
+  const { beforeEach } = useLambdaHooks(test);
+
+  const client = await beforeEach();
+
+  const error = await test.throwsAsync(client.raw({}, {}));
+
+  test.is(error.message, errorMessage);
+});

--- a/test/lambda/entrypoint.test.js
+++ b/test/lambda/entrypoint.test.js
@@ -29,15 +29,16 @@ test.serial('should fail to get entrypoint', async (test) => {
   test.is(error.message, errorMessage);
 });
 
-test.serial('should not fail to get entrypoint', async (test) => {
+test.serial('should return the entry point', async (test) => {
   const imageName = 'random';
+  const entryPoint = ['hello', 'entrypoint'];
   const containerStub = sinon.createStubInstance(Dockerode.Container, {
     inspect: sinon.stub().resolves({ Image: imageName })
   });
   const imageStub = sinon.createStubInstance(Dockerode.Image, {
     inspect: sinon.stub().resolves({
       Config: {
-        Entrypoint: ['hello', 'entrypoint']
+        Entrypoint: entryPoint
       },
       ContainerConfig: {}
     })
@@ -47,5 +48,7 @@ test.serial('should not fail to get entrypoint', async (test) => {
     getImage: sinon.stub().returns(imageStub)
   });
 
-  await test.notThrowsAsync(getEntrypoint(dockerStub, imageName));
+  const result = await getEntrypoint(dockerStub, imageName);
+
+  test.deepEqual(result, entryPoint);
 });


### PR DESCRIPTION
## Changes

- Updated `getEntrypoint` method to remove unneeded `await` since `getImage` doesn't return a promise
- Also updated `getEntrypoint` to check `Config` property for endpoint if it is not present in `ContainerConfig`

This came about when I looked for a potential replacement for [lambci](https://github.com/lambci/lambci) since it appears to be abandoned and I found one called docker-lambda ([github](https://github.com/mLupine/docker-lambda) and [docker hub](https://hub.docker.com/r/mlupin/docker-lambda/tags?page=1&name=nodejs16)) which is forked from lambci, but when testing it out, I kept getting the error `The image ${imageName} has no entrypoint and no parent image`. I noticed that `Entrypoint` was undefined for `ContainerConfig`, but not for the `Config` prop
