### PR TITLE
Fix invalid JSON in examples/dynamodb/package.json

### DIFF
--- a/examples/dynamodb/package.json
+++ b/examples/dynamodb/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "ava": "^0.25.0",
     "@lifeomic/lambda-tools": "file:../../"
-  },
+  }
 }


### PR DESCRIPTION
I found this by running an analysis on all the package.json files in our organization. I'm surprised it hasn't been found before.