### PR TITLE
fix: Handle Missing ContainerConfig on Newer Docker Clients

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -75,7 +75,7 @@ export async function destroyLambdaExecutionEnvironment (environment: ExecutionE
 
 export async function getEntrypoint (docker: Docker, imageName: string): Promise<string[]> {
   const image = await docker.getImage(imageName).inspect();
-  const entryPoint = image.ContainerConfig.Entrypoint ?? image.Config.Entrypoint;
+  const entryPoint = image.ContainerConfig?.Entrypoint ?? image.Config.Entrypoint;
 
   if (entryPoint) {
     return flatten([entryPoint]);

--- a/test/lambda/entrypoint.test.js
+++ b/test/lambda/entrypoint.test.js
@@ -43,8 +43,7 @@ test.serial('should not fail to get entrypoint', async (test) => {
   imageInspectStub.onSecondCall().resolves({
     Config: {
       Entrypoint: ['hello', 'entrypoint']
-    },
-    ContainerConfig: {}
+    }
   });
 
   const imageStub = sinon.createStubInstance(Dockerode.Image, {

--- a/test/localstack/version13Status.test.js
+++ b/test/localstack/version13Status.test.js
@@ -8,7 +8,7 @@ const {
 const services = Object.keys(LOCALSTACK_SERVICES);
 
 test.before(async t => {
-  const { mappedServices, cleanup } = await getConnection({ services, versionTag: '0.13.2' });
+  const { mappedServices, cleanup } = await getConnection({ services, versionTag: '0.13.3' });
   Object.assign(t.context, { mappedServices, cleanup });
 });
 


### PR DESCRIPTION
While upgrading a repo I encountered this error, it seems that `ContainerConfig` is now [removed](https://docs.docker.com/engine/release-notes/26.0) in new docker clients.